### PR TITLE
Ignore List Edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ Likewise, use the `--join-dict-items` or `-jd` option to suppress linebreaks aft
     3
 ], "bar":  "baz"}
 ```
-Finally, use `--condensed` or `-j` to apply both of these options:
+Use `--condensed` or `-j` to apply both of these options:
 ```json
 {"foo": [1, 2, 3], "bar": "baz"}
 ```
+
+The `--only-edits` or `-e` option will print out a list of edits rather than applying them to the input file in place.
 
 ### Matching Options
 By default, Graphtage tries to match all possible pairs of elements in a dictionary. While computationally tractable,

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ Finally, use `--condensed` or `-j` to apply both of these options:
 ### Matching Options
 By default, Graphtage tries to match all possible pairs of elements in a dictionary. While computationally tractable,
 this can sometimes be onerous for input files with huge dictionaries. The `--no-key-edits` or `-k` option will instead
-only attempt to match dictionary items that share the same key, drastically reducing computation.
+only attempt to match dictionary items that share the same key, drastically reducing computation. Likewise, the
+`--no-list-edits` or `-l` option will not consider interstitial insertions and removals when comparing two lists. The
+`--no-list-edits-when-same-length` or `-ll` option is a less drastic version of `-l` that will behave normally for lists
+that are of different lengths, but behave like `-l` for lists that are of the same length.
 
 ### ANSI Color
 By default, Graphtage will only use ANSI color in its output if it is run from a TTY. If, for example, you would like

--- a/graphtage/bounds.py
+++ b/graphtage/bounds.py
@@ -22,6 +22,7 @@ Attributes:
 
 """
 
+import logging
 from functools import wraps
 from typing import Iterable, Iterator, Optional, TypeVar, Union
 from typing_extensions import Protocol
@@ -29,6 +30,9 @@ from typing_extensions import Protocol
 from intervaltree import Interval, IntervalTree
 
 from .fibonacci import FibonacciHeap
+
+
+log = logging.getLogger(__name__)
 
 
 class Infinity:
@@ -247,7 +251,10 @@ def repeat_until_tightened(func):
             if not func(self, *args, **kwargs):
                 return False
             new_bounds = self.bounds()
-            if new_bounds.definitive() or new_bounds.lower_bound > starting_bounds.lower_bound \
+            if new_bounds.lower_bound < starting_bounds.lower_bound \
+                    or new_bounds.upper_bound > starting_bounds.upper_bound:
+                log.warning(f"The most recent call to {func} on {self} returned bounds {new_bounds} when the previous bounds were {starting_bounds}")
+            elif new_bounds.definitive() or new_bounds.lower_bound > starting_bounds.lower_bound \
                     or new_bounds.upper_bound < starting_bounds.upper_bound:
                 return True
 

--- a/graphtage/bounds.py
+++ b/graphtage/bounds.py
@@ -236,20 +236,18 @@ class Bounded(Protocol):
 
 
 def repeat_until_tightened(func):
-    """A decorator that will repeatedly call the function until its bounds are tightened.
+    """A decorator that will repeatedly call the function until its class's bounds are tightened.
 
-    Intended for :meth:`Bounded.tighten_bounds`. The decorated function is expected to return a :class:`bool` to
-    indicate success.
+    Intended for :meth:`Bounded.tighten_bounds`. The value returned by the decorated function is ignored.
 
     """
     @wraps(func)
     def wrapper(self: Bounded, *args, **kwargs):
         starting_bounds = self.bounds()
         if starting_bounds.definitive():
-            return func(self, *args, **kwargs)
+            return False
         while True:
-            if not func(self, *args, **kwargs):
-                return False
+            func(self, *args, **kwargs)
             new_bounds = self.bounds()
             if new_bounds.lower_bound < starting_bounds.lower_bound \
                     or new_bounds.upper_bound > starting_bounds.upper_bound:

--- a/graphtage/csv.py
+++ b/graphtage/csv.py
@@ -7,6 +7,7 @@
 
 import csv
 from io import StringIO
+from typing import Optional
 
 from . import graphtage, json
 from .json import JSONFormatter
@@ -30,17 +31,17 @@ class CSVNode(graphtage.ListNode[CSVRow]):
         return self._children == other._children or (not self and not other)
 
 
-def build_tree(path: str, allow_key_edits=True, *args, **kwargs) -> CSVNode:
+def build_tree(path: str, options: Optional[graphtage.BuildOptions] = None, *args, **kwargs) -> CSVNode:
     """Constructs a :class:`CSVNode` from a CSV file.
 
     The file is parsed using Python's :func:`csv.reader`. The elements in each row are constructed by delegating to
     :func:`graphtage.json.build_tree`::
 
-        CSVRow([json.build_tree(i, allow_key_edits=allow_key_edits) for i in row])
+        CSVRow([json.build_tree(i, options=options) for i in row])
 
     Args:
         path: The path to the file to be parsed.
-        allow_key_edits: This is effectively ignored since CSV files cannot contain mappings.
+        options: Optional build options to pass on to :meth:`graphtage.json.build_tree`.
         *args: Any extra positional arguments are passed on to :func:`csv.reader`.
         **kwargs: Any extra keyword arguments are passed on to :func:`csv.reader`.
 
@@ -51,7 +52,7 @@ def build_tree(path: str, allow_key_edits=True, *args, **kwargs) -> CSVNode:
     csv_data = []
     with open(path) as f:
         for row in csv.reader(f, *args, **kwargs):
-            rowdata = [json.build_tree(i, allow_key_edits=allow_key_edits) for i in row]
+            rowdata = [json.build_tree(i, options=options) for i in row]
             for col in rowdata:
                 if isinstance(col, graphtage.StringNode):
                     col.quoted = False
@@ -164,12 +165,12 @@ class CSV(graphtage.Filetype):
             'text/csv'
         )
 
-    def build_tree(self, path: str, allow_key_edits: bool = True) -> TreeNode:
+    def build_tree(self, path: str, options: Optional[graphtage.BuildOptions] = None) -> TreeNode:
         """Equivalent to :func:`build_tree`"""
-        return build_tree(path, allow_key_edits=allow_key_edits)
+        return build_tree(path, options=options)
 
-    def build_tree_handling_errors(self, path: str, allow_key_edits: bool = True) -> TreeNode:
-        return self.build_tree(path=path, allow_key_edits=allow_key_edits)
+    def build_tree_handling_errors(self, path: str, options: Optional[graphtage.BuildOptions] = None) -> TreeNode:
+        return self.build_tree(path=path, options=options)
 
     def get_default_formatter(self) -> CSVFormatter:
         return CSVFormatter.DEFAULT_INSTANCE

--- a/graphtage/graphtage.py
+++ b/graphtage/graphtage.py
@@ -213,7 +213,7 @@ class KeyValuePairNode(ContainerNode):
         self.value.print(printer)
 
     def calculate_total_size(self):
-        return self.key.total_size + self.value.total_size
+        return self.key.total_size + self.value.total_size + 2
 
     def __lt__(self, other):
         """ Compares this key/value pair to another.
@@ -362,7 +362,7 @@ class MultiSetNode(SequenceNode[HashableCounter[T]], Generic[T]):
             return Replace(self, node)
 
     def calculate_total_size(self):
-        return sum(c.total_size * count for c, count in self._children.items())
+        return sum((c.total_size + 1) * count for c, count in self._children.items())
 
     def __len__(self):
         return sum(self._children.values())

--- a/graphtage/graphtage.py
+++ b/graphtage/graphtage.py
@@ -10,7 +10,7 @@ from .edits import Insert, Match, Remove, Replace, AbstractCompoundEdit
 from .levenshtein import EditDistance, levenshtein_distance
 from .multiset import MultiSetEdit
 from .printer import Back, Fore, NullANSIContext, Printer
-from .sequences import SequenceEdit, SequenceNode
+from .sequences import FixedLengthSequenceEdit, SequenceEdit, SequenceNode
 from .tree import ContainerNode, Edit, GraphtageFormatter, TreeNode
 from .utils import HashableCounter
 
@@ -299,10 +299,10 @@ class ListNode(SequenceNode[Tuple[T, ...]], Generic[T]):
             if len(self._children) == len(node._children) == 0:
                 return Match(self, node, 0)
             elif len(self._children) == len(node._children) == 1:
-                return EditSequence(from_node=self, to_node=node, edits=iter((
-                    Match(self, node, 0),
-                    self._children[0].edits(node._children[0])
-                )))
+                return FixedLengthSequenceEdit(
+                    from_node=self,
+                    to_node=node
+                )
             elif self._children == node._children:
                 return Match(self, node, 0)
             else:

--- a/graphtage/json.py
+++ b/graphtage/json.py
@@ -36,6 +36,8 @@ def build_tree(
         ValueError: If the object is of an unsupported type.
 
     """
+    if options is None:
+        options = BuildOptions()
     if isinstance(python_obj, bool):
         return BoolNode(python_obj)
     elif isinstance(python_obj, int):

--- a/graphtage/json.py
+++ b/graphtage/json.py
@@ -49,7 +49,11 @@ def build_tree(
     elif force_leaf_node:
         raise ValueError(f"{python_obj!r} was expected to be an int or string, but was instead a {type(python_obj)}")
     elif isinstance(python_obj, list) or isinstance(python_obj, tuple):
-        return ListNode([build_tree(n, options=options) for n in python_obj])
+        return ListNode(
+            [build_tree(n, options=options) for n in python_obj],
+            allow_list_edits=options.allow_list_edits,
+            allow_list_edits_when_same_length=options.allow_list_edits_when_same_length
+        )
     elif isinstance(python_obj, dict):
         dict_items = {
             build_tree(k, options=options, force_leaf_node=True):

--- a/graphtage/json.py
+++ b/graphtage/json.py
@@ -7,9 +7,9 @@
 
 import json
 import os
-from typing import Union
+from typing import Optional, Union
 
-from .graphtage import BoolNode, DictNode, Filetype, FixedKeyDictNode, \
+from .graphtage import BoolNode, BuildOptions, DictNode, Filetype, FixedKeyDictNode, \
     FloatNode, IntegerNode, KeyValuePairNode, LeafNode, ListNode, StringFormatter, StringNode
 from .printer import Fore, Printer
 from .sequences import SequenceFormatter
@@ -18,13 +18,13 @@ from .tree import GraphtageFormatter, TreeNode
 
 def build_tree(
         python_obj: Union[int, float, bool, str, bytes, list, dict],
-        allow_key_edits: bool = True,
+        options: Optional[BuildOptions] = None,
         force_leaf_node: bool = False) -> TreeNode:
     """Builds a Graphtage tree from an arbitrary Python object.
 
     Args:
         python_obj: The object from which to build the tree.
-        allow_key_edits: Whether or not to try and match key/value pairs in dicts if their keys differ.
+        options: An optional set of options for building the tree.
         force_leaf_node: If :const:`True`, assume that :obj:`python_obj` is *not* a :func:`list` or :func:`dict`.
 
     Returns:
@@ -49,13 +49,13 @@ def build_tree(
     elif force_leaf_node:
         raise ValueError(f"{python_obj!r} was expected to be an int or string, but was instead a {type(python_obj)}")
     elif isinstance(python_obj, list) or isinstance(python_obj, tuple):
-        return ListNode([build_tree(n, allow_key_edits=allow_key_edits) for n in python_obj])
+        return ListNode([build_tree(n, options=options) for n in python_obj])
     elif isinstance(python_obj, dict):
         dict_items = {
-            build_tree(k, allow_key_edits=allow_key_edits, force_leaf_node=True):
-                build_tree(v, allow_key_edits=allow_key_edits) for k, v in python_obj.items()
+            build_tree(k, options=options, force_leaf_node=True):
+                build_tree(v, options=options) for k, v in python_obj.items()
         }
-        if allow_key_edits:
+        if options is None or options.allow_key_edits:
             return DictNode.from_dict(dict_items)
         else:
             return FixedKeyDictNode.from_dict(dict_items)
@@ -216,13 +216,13 @@ class JSON(Filetype):
             'text/x-json'
         )
 
-    def build_tree(self, path: str, allow_key_edits: bool = True) -> TreeNode:
+    def build_tree(self, path: str, options: Optional[BuildOptions] = None) -> TreeNode:
         with open(path) as f:
-            return build_tree(json.load(f), allow_key_edits=allow_key_edits)
+            return build_tree(json.load(f), options)
 
-    def build_tree_handling_errors(self, path: str, allow_key_edits: bool = True) -> Union[str, TreeNode]:
+    def build_tree_handling_errors(self, path: str, options: Optional[BuildOptions] = None) -> Union[str, TreeNode]:
         try:
-            return self.build_tree(path=path, allow_key_edits=allow_key_edits)
+            return self.build_tree(path=path, options=options)
         except json.decoder.JSONDecodeError as de:
             return f'Error parsing {os.path.basename(path)}: {de.msg}: line {de.lineno}, column {de.colno} (char {de.pos})'
 

--- a/graphtage/levenshtein.py
+++ b/graphtage/levenshtein.py
@@ -268,7 +268,7 @@ class EditDistance(SequenceEdit):
 
                 with DEFAULT_PRINTER.tqdm(
                         total=fringe_total,
-                        initial=fringe_total,
+                        initial=0,
                         desc=f"Tightening Fringe Diagonal {self._fringe_row + self._fringe_col}",
                         disable=fringe_total <= 0,
                         leave=False

--- a/graphtage/levenshtein.py
+++ b/graphtage/levenshtein.py
@@ -262,17 +262,22 @@ class EditDistance(SequenceEdit):
                 if DEFAULT_PRINTER.quiet:
                     fringe_ranges = {}
                     fringe_total = 0
+                    num_diagonals = 0
                 else:
                     fringe_ranges = {
-                        (row, col): self.edit_matrix[row][col].bounds().upper_bound - self.edit_matrix[row][col].bounds().lower_bound
+                        (row, col): (
+                            self.edit_matrix[row][col].bounds().upper_bound
+                            - self.edit_matrix[row][col].bounds().lower_bound
+                        )
                         for row, col in self._fringe_diagonal()
                     }
                     fringe_total = sum(fringe_ranges.values())
+                    num_diagonals = len(self.from_seq) + len(self.to_seq)
 
                 with DEFAULT_PRINTER.tqdm(
                         total=fringe_total,
                         initial=0,
-                        desc=f"Tightening Fringe Diagonal {self._fringe_row + self._fringe_col}",
+                        desc=f"Tightening Fringe Diagonal {self._fringe_row + self._fringe_col} of {num_diagonals}",
                         disable=fringe_total <= 0,
                         leave=False
                 ) as t:

--- a/graphtage/sequences.py
+++ b/graphtage/sequences.py
@@ -69,67 +69,30 @@ class FixedLengthSequenceEdit(SequenceEdit):
         if len(from_node) != len(to_node):
             raise ValueError("Both sequence nodes must have the same number of elements!")
 
-        self._pair_iter: Optional[Iterator[Tuple[TreeNode, TreeNode]]] = zip(from_node, to_node)
-
-        self._sub_edits: List[Edit] = []
-
-        self._pair_sizes: List[int] = [f.total_size + t.total_size + 1 for f, t in zip(from_node, to_node)]
+        self._sub_edits: List[Edit] = [from_child.edits(to_child) for from_child, to_child in zip(from_node, to_node)]
 
         super().__init__(from_node=from_node, to_node=to_node)
 
     def edits(self) -> Iterator[Edit]:
-        yield from self._sub_edits
-        while True:
-            edit = self._expand_next_pair()
-            if edit is None:
-                break
-            else:
-                yield edit
-
-    def _expand_next_pair(self) -> Optional[Edit]:
-        if self._pair_iter is None:
-            return None
-        try:
-            next_from, next_to = next(self._pair_iter)
-            edit = next_from.edits(next_to)
-            self._sub_edits.append(edit)
-            return edit
-        except StopIteration:
-            self._pair_iter = None
-            return None
+        return iter(self._sub_edits)
 
     def is_complete(self) -> bool:
-        return self._pair_iter is None and all(edit.is_complete() for edit in self._sub_edits)
+        return all(edit.is_complete() for edit in self._sub_edits)
 
     @repeat_until_tightened
     def tighten_bounds(self) -> bool:
-        while self._pair_iter is not None:
-            next_edit = self._expand_next_pair()
-            if next_edit is not None and next_edit.tighten_bounds():
-                return True
         for edit in self._sub_edits:
             if edit.tighten_bounds():
                 return True
         return False
 
     def bounds(self) -> Range:
-        if len(self._sub_edits) == len(self.sequence):
-            lb = 0
-            ub = 0
-            for edit in self._sub_edits:
-                b = edit.bounds()
-                lb += b.lower_bound
-                ub += b.upper_bound
-            return Range(lb, ub)
-
         lb = 0
-        ub = self.from_node.total_size + self.to_node.total_size + 1
-        for original_ub, edit in zip(self._pair_sizes, self._sub_edits):
+        ub = 0
+        for edit in self._sub_edits:
             b = edit.bounds()
-            if b.upper_bound > original_ub:
-                raise ValueError(f"Upper bound of edit {edit} is greater than the cost of a Replace")
             lb += b.lower_bound
-            ub -= original_ub - b.upper_bound
+            ub += b.upper_bound
         return Range(lb, ub)
 
 

--- a/graphtage/sequences.py
+++ b/graphtage/sequences.py
@@ -154,7 +154,7 @@ class SequenceNode(ContainerNode, Generic[T], ABC):
             return sum(c.total_size for c in self)
 
         """
-        return sum(c.total_size for c in self)
+        return sum(c.total_size + 1 for c in self)
 
     def __eq__(self, other):
         return isinstance(other, SequenceNode) and self._children == other._children

--- a/graphtage/sequences.py
+++ b/graphtage/sequences.py
@@ -1,5 +1,6 @@
 """Abstract base classes for representing sequences in Graphtage's intermediate representation."""
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, Callable, cast, Dict, Generic, Iterable, Iterator, List, Optional, Sequence, Tuple, \
     Type, TypeVar
@@ -8,6 +9,9 @@ from .bounds import Range, repeat_until_tightened
 from .edits import AbstractCompoundEdit, Insert, Match, Remove
 from .printer import Printer
 from .tree import ContainerNode, Edit, EditedTreeNode, GraphtageFormatter, TreeNode
+
+
+log = logging.getLogger(__name__)
 
 
 class SequenceEdit(AbstractCompoundEdit, ABC):
@@ -82,7 +86,11 @@ class FixedLengthSequenceEdit(SequenceEdit):
     @repeat_until_tightened
     def tighten_bounds(self) -> bool:
         for edit in self._sub_edits:
+            prev_bounds = edit.bounds()
             if edit.tighten_bounds():
+                new_bounds = edit.bounds()
+                if prev_bounds.lower_bound > new_bounds.lower_bound or prev_bounds.upper_bound < new_bounds.upper_bound:
+                    log.warning(f"The most recent call to `tighten_bounds()` on edit {edit} tightened its bounds from {prev_bounds} to {new_bounds}")
                 return True
         return False
 

--- a/graphtage/tree.py
+++ b/graphtage/tree.py
@@ -502,6 +502,8 @@ class TreeNode(metaclass=ABCMeta):
             while edit.valid and not edit.is_complete() and edit.tighten_bounds():
                 new_bounds = edit.bounds()
                 new_range = new_bounds.upper_bound - new_bounds.lower_bound
+                if prev_range < new_range:
+                    log.warning(f"The most recent call to `tighten_bounds()` on edit {edit} tightened its bounds from {prev_bounds} to {new_bounds}")
                 t.update(prev_range - new_range)
                 prev_range = new_range
         edit.on_diff(ret)

--- a/graphtage/utils.py
+++ b/graphtage/utils.py
@@ -5,6 +5,7 @@ import sys
 import tempfile as tf
 from collections import Counter, OrderedDict
 from collections.abc import Iterable
+from collections.abc import Sized as AbstractSized
 from typing import Any, Callable, Dict, Generic, Optional, IO, Iterator, Mapping, MutableMapping, Tuple, TypeVar, Union
 from typing import Iterable as IterableType
 from typing_extensions import Protocol
@@ -392,6 +393,10 @@ def smallest(*sequence: Union[T, IterableType[T]], n: int = 1, key: Optional[Cal
     if len(sequence) == 1 and isinstance(sequence, Iterable):
         sequence = sequence[0]
 
+    if isinstance(sequence, AbstractSized) and len(sequence) <= n:
+        yield from sequence
+        return
+
     heap: FibonacciHeap[T, T] = FibonacciHeap(key=key)
 
     for s in sequence:
@@ -406,6 +411,10 @@ def smallest(*sequence: Union[T, IterableType[T]], n: int = 1, key: Optional[Cal
 def largest(*sequence: Union[T, IterableType[T]], n: int = 1, key: Optional[Callable[[T], Any]] = None) -> Iterator[T]:
     if len(sequence) == 1 and isinstance(sequence, Iterable):
         sequence = sequence[0]
+
+    if isinstance(sequence, AbstractSized) and len(sequence) <= n:
+        yield from sequence
+        return
 
     heap: MaxFibonacciHeap[T, Any] = MaxFibonacciHeap(key=key)
 

--- a/graphtage/utils.py
+++ b/graphtage/utils.py
@@ -5,7 +5,7 @@ import sys
 import tempfile as tf
 from collections import Counter, OrderedDict
 from collections.abc import Iterable
-from typing import Callable, Dict, Generic, Optional, IO, Iterator, Mapping, MutableMapping, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, Optional, IO, Iterator, Mapping, MutableMapping, Tuple, TypeVar, Union
 from typing import Iterable as IterableType
 from typing_extensions import Protocol
 import typing
@@ -388,11 +388,11 @@ class Tempfile:
             self._temp = None
 
 
-def smallest(*sequence: Union[T, IterableType[T]], n: int = 1) -> Iterator[T]:
+def smallest(*sequence: Union[T, IterableType[T]], n: int = 1, key: Optional[Callable[[T], Any]] = None) -> Iterator[T]:
     if len(sequence) == 1 and isinstance(sequence, Iterable):
         sequence = sequence[0]
 
-    heap: FibonacciHeap[T, T] = FibonacciHeap()
+    heap: FibonacciHeap[T, T] = FibonacciHeap(key=key)
 
     for s in sequence:
         heap.push(s)
@@ -403,11 +403,11 @@ def smallest(*sequence: Union[T, IterableType[T]], n: int = 1) -> Iterator[T]:
         yield heap.pop()
 
 
-def largest(*sequence: Union[T, IterableType[T]], n: int = 1) -> Iterator[T]:
+def largest(*sequence: Union[T, IterableType[T]], n: int = 1, key: Optional[Callable[[T], Any]] = None) -> Iterator[T]:
     if len(sequence) == 1 and isinstance(sequence, Iterable):
         sequence = sequence[0]
 
-    heap: MaxFibonacciHeap[T, T] = MaxFibonacciHeap()
+    heap: MaxFibonacciHeap[T, Any] = MaxFibonacciHeap(key=key)
 
     for s in sequence:
         heap.push(s)

--- a/graphtage/utils.py
+++ b/graphtage/utils.py
@@ -4,9 +4,13 @@ import os
 import sys
 import tempfile as tf
 from collections import Counter, OrderedDict
+from collections.abc import Iterable
 from typing import Callable, Dict, Generic, Optional, IO, Iterator, Mapping, MutableMapping, Tuple, TypeVar, Union
+from typing import Iterable as IterableType
 from typing_extensions import Protocol
 import typing
+
+from .fibonacci import FibonacciHeap, MaxFibonacciHeap
 
 T = TypeVar('T')
 
@@ -382,3 +386,33 @@ class Tempfile:
         if self._temp is not None:
             os.unlink(self._temp.name)
             self._temp = None
+
+
+def smallest(*sequence: Union[T, IterableType[T]], n: int = 1) -> Iterator[T]:
+    if len(sequence) == 1 and isinstance(sequence, Iterable):
+        sequence = sequence[0]
+
+    heap: FibonacciHeap[T, T] = FibonacciHeap()
+
+    for s in sequence:
+        heap.push(s)
+
+    for _ in range(n):
+        if not heap:
+            break
+        yield heap.pop()
+
+
+def largest(*sequence: Union[T, IterableType[T]], n: int = 1) -> Iterator[T]:
+    if len(sequence) == 1 and isinstance(sequence, Iterable):
+        sequence = sequence[0]
+
+    heap: MaxFibonacciHeap[T, T] = MaxFibonacciHeap()
+
+    for s in sequence:
+        heap.push(s)
+
+    for _ in range(n):
+        if not heap:
+            break
+        yield heap.pop()

--- a/graphtage/version.py
+++ b/graphtage/version.py
@@ -48,7 +48,7 @@ def git_branch() -> Optional[str]:
         return None
 
 
-DEV_BUILD = True
+DEV_BUILD = False
 """Sets whether this build is a development build.
 
 This should only be set to :const:`True` to coincide with a release. It should *always* be :const:`True` before

--- a/test/test_graphtage.py
+++ b/test/test_graphtage.py
@@ -91,6 +91,13 @@ class TestGraphtage(TestCase):
             else:
                 self.assertIsInstance(edit, graphtage.Match)
 
+    def test_single_element_list(self):
+        diff = graphtage.json.build_tree([1]).diff(graphtage.json.build_tree([2]))
+        self.assertIsInstance(diff, graphtage.ListNode)
+        self.assertIsInstance(diff, graphtage.tree.EditedTreeNode)
+        self.assertEqual(1, len(diff.edit_list))
+        self.assertIsInstance(diff.edit_list[0], graphtage.FixedLengthSequenceEdit)
+
     def test_empty_list(self):
         diff = graphtage.ListNode(()).diff(graphtage.ListNode(()))
         self.assertEqual(1, len(diff.edit_list))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,7 @@
 import sys
 from unittest import TestCase
 
-from graphtage.utils import SparseMatrix
+from graphtage.utils import largest, smallest, SparseMatrix
 
 
 class TestSparseMatrix(TestCase):
@@ -37,3 +37,15 @@ class TestSparseMatrix(TestCase):
         self.assertEqual((11, 21), matrix.shape())
         matrix = SparseMatrix(num_rows=10, num_cols=10)
         self.assertEqual((10, 10), matrix.shape())
+
+    def test_smallest(self):
+        for i in smallest(range(1000), n=10):
+            self.assertGreater(10, i)
+        for i in smallest(*list(range(1000)), n=10):
+            self.assertGreater(10, i)
+
+    def test_largest(self):
+        for i in largest(range(1000), n=10):
+            self.assertLess(1000 - 11, i)
+        for i in largest(*list(range(1000)), n=10):
+            self.assertLess(1000 - 11, i)


### PR DESCRIPTION
Adds command line options to ignore editing lists. See #13.

Also fixes some bugs in bounds calculations.