### PR TITLE
Packaging tweaks for downstreams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-graphtage.egg-info
 __pycache__
-*.pyc
-.python_history
 .cache
+.python_history
+*.pyc
+build/
+dist/
+graphtage.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+recursive-include test *.*

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 Graphtage is a commandline utility and [underlying library](https://trailofbits.github.io/graphtage/latest/library.html)
 for semantically comparing and merging tree-like structures, such as JSON, XML, HTML, YAML, and CSS files. Its name is a
 portmanteau of “graph” and “graftage”—the latter being the horticultural practice of joining two trees together such
-that they grow as one. 
+that they grow as one.
 
 <p align="center">
-  <img src="docs/example.png?raw=true" title="Graphtage Example">
+  <img src="https://raw.githubusercontent.com/trailofbits/graphtage/master/docs/example.png" title="Graphtage Example">
 </p>
- 
+
 ## Installation
- 
+
 ```console
 $ pip3 install graphtage
 ```

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,14 @@ def get_readme():
 setup(
     name='graphtage',
     description='A utility to diff tree-like files such as JSON and XML.',
-    long_description=open(README_PATH).read(),
+    long_description=get_readme(),
     long_description_content_type="text/markdown",
     url='https://github.com/trailofbits/graphtage',
+    project_urls={
+        'Documentation': 'https://trailofbits.github.io/graphtage',
+        'Source': 'https://github.com/trailofbits/graphtage',
+        'Tracker': 'https://github.com/trailofbits/graphtage/issues',
+    },
     author='Trail of Bits',
     version=get_version_string(),
     packages=find_packages(exclude=['test']),

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ def get_readme():
 setup(
     name='graphtage',
     description='A utility to diff tree-like files such as JSON and XML.',
+    license="LGPL-3.0-or-later",
     long_description=get_readme(),
     long_description_content_type="text/markdown",
     url='https://github.com/trailofbits/graphtage',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url='https://github.com/trailofbits/graphtage',
     author='Trail of Bits',
     version=get_version_string(),
-    packages=find_packages(),
+    packages=find_packages(exclude=['test']),
     python_requires='>=3.6',
     install_requires=[
         'colorama',
@@ -43,5 +43,6 @@ setup(
         'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Utilities'
-    ]
+    ],
+    include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION_MODULE_PATH = os.path.join(os.path.realpath(os.path.dirname(__file__)), "graphtage", "version.py")
+HERE = os.path.realpath(os.path.dirname(__file__))
+
+VERSION_MODULE_PATH = os.path.join(HERE, "graphtage", "version.py")
+README_PATH = os.path.join(HERE, "README.md")
 
 
 def get_version_string():
@@ -11,9 +14,16 @@ def get_version_string():
     return version['VERSION_STRING']
 
 
+def get_readme():
+    with open(README_PATH) as f:
+        return f.read()
+
+
 setup(
     name='graphtage',
     description='A utility to diff tree-like files such as JSON and XML.',
+    long_description=open(README_PATH).read(),
+    long_description_content_type="text/markdown",
     url='https://github.com/trailofbits/graphtage',
     author='Trail of Bits',
     version=get_version_string(),
@@ -34,7 +44,7 @@ setup(
         ]
     },
     extras_require={
-        "dev": ["flake8", "Sphinx", "pytest", "sphinx_rtd_theme==0.4.3"]
+        "dev": ["flake8", "Sphinx", "pytest", "sphinx_rtd_theme==0.4.3", "twine"]
     },
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def get_version_string():
 
 
 def get_readme():
-    with open(README_PATH) as f:
+    with open(README_PATH, encoding='utf-8') as f:
         return f.read()
 
 


### PR DESCRIPTION
Hello! Thanks for this interesting tool!

I'd like to package this for [conda-forge](https://github.com/conda-forge/staged-recipes), started down that path, and ran into some issues with what ends up in the `sdist`. Would probably need (most) of the below in the next release to answer the mail and make maintaining it straightforward.

- when installed, creates a module in `site-packages` called `test`!
  - [x] `ignore` `test` in `find_packages`
- i want to run the tests and package the license!
  - [x] package the `test` and `LICENSE` via `MANIFEST.in` and `include_package_data`
- the pypi page is pretty empty!
  - [x] add the SPDX identifier to `license` and `README.md` to `long_description` in `setup.py`
  - [x] point the screenshot to github (so it will show up on pypi)
  - [x] add some project links (docs, issues) to fill out the left bar on pypi
  - [x] add `twine` to the `dev` extras so it can upload the markdown

I've tested this locally (on linux), and appears to answer the mail, run the tests, etc.

Thanks again!