### PR TITLE
Support for Python 3.9

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -17,6 +17,7 @@
             {% endfor %}
           {% else %}
             <dd><a href="/graphtage/latest">latest</a></dd>
+            <dd><a href="/graphtage/v0.2.4">0.2.4</a></dd>
             <dd><a href="/graphtage/v0.2.3">0.2.3</a></dd>
             <dd><a href="/graphtage/v0.2.2">0.2.2</a></dd>
             <dd><a href="/graphtage/v0.2.1">0.2.1</a></dd>

--- a/graphtage/matching.py
+++ b/graphtage/matching.py
@@ -260,7 +260,7 @@ class Matching(Generic[T], SetCollection, Bounded, SetType):
         return f'{self.__class__.__name__}<{matchings}>'
 
 
-class PathSet(Generic[T], Matching[T]):
+class PathSet(Matching[T], Generic[T]):
     """A version of a Matching with edge directions overridden, used for [Karp78]_"""
     def __init__(self):
         super().__init__()

--- a/graphtage/version.py
+++ b/graphtage/version.py
@@ -48,7 +48,7 @@ def git_branch() -> Optional[str]:
         return None
 
 
-DEV_BUILD = True
+DEV_BUILD = False
 """Sets whether this build is a development build.
 
 This should only be set to :const:`False` to coincide with a release. It should *always* be :const:`False` before

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'colorama',
         'intervaltree',
         'json5==0.9.5',
+        'numpy>=1.19.4',
         'PyYAML',
         'scipy>=1.4.0',
         'tqdm',


### PR DESCRIPTION
Fixes an MRO inheritance issue that was preventing Graphtage from running on Python 3.9. Also added Python 3.9 to the tests in CI. Fixes #36.