### PR TITLE
Include support for YAML files with multiple documents in stream

### DIFF
--- a/graphtage/yaml.py
+++ b/graphtage/yaml.py
@@ -3,7 +3,7 @@ import os
 from io import StringIO
 from typing import Optional, Union
 
-from yaml import dump, load, YAMLError
+from yaml import dump, load_all, YAMLError
 try:
     from yaml import CLoader as Loader, CDumper as Dumper
 except ImportError:
@@ -21,8 +21,15 @@ from .tree import ContainerNode, Edit, GraphtageFormatter, TreeNode
 def build_tree(path: str, options: Optional[BuildOptions] = None, *args, **kwargs) -> TreeNode:
     """Constructs a YAML tree from an YAML file."""
     with open(path, 'rb') as stream:
-        data = load(stream, Loader=Loader)
-        return json.build_tree(data, options=options, *args, **kwargs)
+        document_stream = load_all(stream, Loader=Loader)
+        documents = list(document_stream)
+        if len(documents) == 0:
+            return json.build_tree(None, options=options, *args, **kwargs)
+        elif len(documents) > 1:
+            return json.build_tree(documents, options=options, *args, **kwargs)
+        else:
+            singleton = documents[0]
+            return json.build_tree(singleton, options=options, *args, **kwargs)
 
 
 class YAMLListFormatter(SequenceFormatter):


### PR DESCRIPTION
YAML supports multiple documents in one stream. This entails that YAML files could be viewed as a forest rather than a single tree. Graphtage supports only tree-like files.

Support multi-document YAML files by considering each document as an array element, i.e. consider each document as part of the same tree. These changes is fully backwards compatible as it considers single-document YAML streams as a single node.

---

An alternative approach to this solution would be to go through each document as separate trees and diffing them. However, this approach would include overhead in changes, such as traversing each tree separately and considering trees of different depth.

An addition could be to sort the array before diffing. However, this addition would not reflect the reality of the files as the order of documents are dropped.

---

Motivation:
- In my use-case I would like to diff configuration files written in YAML. In some cases, e.g. for Kubernetes, one YAML file can include multiple documents as part of the configuration.
  - Graphtage would help me massively to properly diff configuration files instead of having to use text-based diffing methods. However, multi-document support is a must for that to be viable.