### PR TITLE
Optimizations to the dictionary comparison strategy

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -9,9 +9,40 @@ for semantically comparing and merging tree-like structures, such as JSON, XML, 
 portmanteau of “graph” and “graftage”—the latter being the horticultural practice of joining two trees together such
 that they grow as one.
 
-<p align="center">
-  <img src="https://raw.githubusercontent.com/trailofbits/graphtage/master/docs/example.png" title="Graphtage Example">
-</p>
+```console
+$ echo Original: && cat original.json && echo Modified: && cat modified.json
+```
+```json
+Original:
+{
+    "foo": [1, 2, 3, 4],
+    "bar": "testing"
+}
+Modified:
+{
+    "foo": [2, 3, 4, 5],
+    "zab": "testing",
+    "woo": ["foobar"]
+}
+```
+```console
+$ graphtage original.json modified.json
+```
+```json
+{
+    "z̟b̶ab̟r̶": "testing",
+    "foo": [
+        1̶,̶
+        2,
+        3,
+        4,̟
+        5̟
+    ],̟
+    "̟w̟o̟o̟"̟:̟ ̟[̟
+        "̟f̟o̟o̟b̟a̟r̟"̟
+    ]̟
+}
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Graphtage performs an analysis on an intermediate representation of the trees th
 input files. This means, for example, that you can diff a JSON file against a YAML file. Also, the output format can be
 different from the input format(s). By default, Graphtage will format the output diff in the same file format as the
 first input file. But one could, for example, diff two JSON files and format the output in YAML. There are several
-command-line arguments to specify these transformations; please check the `--help` output for more information.
+command-line arguments to specify these transformations, such as `--format`; please check the `--help` output for more
+information.
 
 By default, Graphtage pretty-prints its output with as many line breaks and indents as possible.
 ```json

--- a/README.md
+++ b/README.md
@@ -94,12 +94,23 @@ Use `--condensed` or `-j` to apply both of these options:
 The `--only-edits` or `-e` option will print out a list of edits rather than applying them to the input file in place.
 
 ### Matching Options
-By default, Graphtage tries to match all possible pairs of elements in a dictionary. While computationally tractable,
-this can sometimes be onerous for input files with huge dictionaries. The `--no-key-edits` or `-k` option will instead
-only attempt to match dictionary items that share the same key, drastically reducing computation. Likewise, the
-`--no-list-edits` or `-l` option will not consider interstitial insertions and removals when comparing two lists. The
-`--no-list-edits-when-same-length` or `-ll` option is a less drastic version of `-l` that will behave normally for lists
-that are of different lengths but behave like `-l` for lists that are of the same length.
+By default, Graphtage tries to match all possible pairs of elements in a dictionary.
+
+Matching two dictionaries with each other is hard. Although computationally tractable, this can sometimes be onerous for 
+input files with huge dictionaries. Graphtage has three different strategies for matching dictionaries:
+1. `--dict-strategy match` (the most computationally expensive) tries to match all pairs of keys and values between the
+   two dictionaries, resulting in a match of minimum edit distance;
+2. `--dict-strategy none` (the least computationally expensive) will not attempt to match any key/value pairs unless
+   they have the exact same key; and
+3. `--dict-strategy auto` (the default) will automatically match the values of any key-value pairs that have identical
+   keys and then use the `match` strategy for the remainder of key/value pairs.
+
+See [Pull Request #51](https://github.com/trailofbits/graphtage/pull/51) for some examples of how these strategies
+affect output.
+
+The `--no-list-edits` or `-l` option will not consider interstitial insertions and removals when comparing two lists.
+The `--no-list-edits-when-same-length` or `-ll` option is a less drastic version of `-l` that will behave normally for
+lists that are of different lengths but behave like `-l` for lists that are of the same length.
 
 ### ANSI Color
 By default, Graphtage will only use ANSI color in its output if it is run from a TTY. If, for example, you would like

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -17,6 +17,7 @@
             {% endfor %}
           {% else %}
             <dd><a href="/graphtage/latest">latest</a></dd>
+            <dd><a href="/graphtage/v0.2.6">0.2.6</a></dd>
             <dd><a href="/graphtage/v0.2.5">0.2.5</a></dd>
             <dd><a href="/graphtage/v0.2.4">0.2.4</a></dd>
             <dd><a href="/graphtage/v0.2.3">0.2.3</a></dd>

--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -139,7 +139,7 @@ def main(argv=None) -> int:
     formatting.add_argument('--condensed', '-j', action='store_true', help='equivalent to `-jl -jd`')
     formatting.add_argument('--html', action='store_true', help='output the diff in HTML')
     key_match_strategy = parser.add_mutually_exclusive_group()
-    key_match_strategy.add_argument("--dict-strategy", choices=("auto", "match", "none"),
+    key_match_strategy.add_argument("--dict-strategy", "-ds", choices=("auto", "match", "none"),
                                     help="sets the strategy for matching dictionary key/value pairs: `auto` (the "
                                          "default) will automatically match two key/value pairs if they share the "
                                          "same key, but consider key edits for all non-identical keys; `match` will "

--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -135,14 +135,23 @@ def main(argv=None) -> int:
     formatting.add_argument('--join-lists', '-jl', action='store_true',
                             help='do not print a newline after each list entry')
     formatting.add_argument('--join-dict-items', '-jd', action='store_true',
-                        help='do not print a newline after each key/value pair in a dictionary')
+                            help='do not print a newline after each key/value pair in a dictionary')
     formatting.add_argument('--condensed', '-j', action='store_true', help='equivalent to `-jl -jd`')
     formatting.add_argument('--html', action='store_true', help='output the diff in HTML')
-    parser.add_argument(
+    key_match_strategy = parser.add_mutually_exclusive_group()
+    key_match_strategy.add_argument("--dict-strategy", choices=("auto", "match", "none"),
+                                    help="sets the strategy for matching dictionary key/value pairs: `auto` (the "
+                                         "default) will automatically match two key/value pairs if they share the "
+                                         "same key, but consider key edits for all non-identical keys; `match` will "
+                                         "attempt to consider all possible key edits (the most computationally "
+                                         "expensive); and `none` will not consider any edits on dictionary keys (the "
+                                         "least computationally expensive)")
+    key_match_strategy.add_argument(
         '--no-key-edits',
         '-k',
         action='store_true',
-        help='only match dictionary entries if they share the same key. This drastically reduces computation.'
+        help='only match dictionary entries if they share the same key, drastically reducing computation; this is '
+             'equivalent to `--dict-strategy none`'
     )
     list_edit_group = parser.add_mutually_exclusive_group()
     list_edit_group.add_argument(
@@ -273,8 +282,22 @@ def main(argv=None) -> int:
     else:
         match_unless = None
 
+    if args.dict_strategy == "none":
+        allow_key_edits = False
+        auto_match_keys = False
+    elif args.dict_strategy == "auto":
+        allow_key_edits = True
+        auto_match_keys = True
+    elif args.dict_strategy == "match":
+        allow_key_edits = True
+        auto_match_keys = False
+    else:
+        allow_key_edits = not args.no_key_edits
+        auto_match_keys = allow_key_edits
+
     options = graphtage.BuildOptions(
-        allow_key_edits=not args.no_key_edits,
+        allow_key_edits=allow_key_edits,
+        auto_match_keys=auto_match_keys,
         allow_list_edits=not args.no_list_edits,
         allow_list_edits_when_same_length=not args.no_list_edits_when_same_length
     )

--- a/graphtage/graphtage.py
+++ b/graphtage/graphtage.py
@@ -338,10 +338,11 @@ class ListNode(SequenceNode[Tuple[T, ...]], Generic[T]):
 class MultiSetNode(SequenceNode[HashableCounter[T]], Generic[T]):
     """A node representing a set that can contain duplicate items."""
 
-    def __init__(self, items: Iterable[T]):
+    def __init__(self, items: Iterable[T], auto_match_keys: bool = True):
         if not isinstance(items, HashableCounter):
             items = HashableCounter(items)
         super().__init__(items)
+        self.auto_match_keys: bool = auto_match_keys
 
     def to_obj(self):
         return HashableCounter(n.to_obj() for n in self)
@@ -357,7 +358,7 @@ class MultiSetNode(SequenceNode[HashableCounter[T]], Generic[T]):
             elif self._children == node._children:
                 return Match(self, node, 0)
             else:
-                return MultiSetEdit(self, node, self._children, node._children)
+                return MultiSetEdit(self, node, self._children, node._children, auto_match_keys=self.auto_match_keys)
         else:
             return Replace(self, node)
 
@@ -910,6 +911,7 @@ class BuildOptions:
 
     def __init__(self, *,
                  allow_key_edits=True,
+                 auto_match_keys=True,
                  allow_list_edits=True,
                  allow_list_edits_when_same_length=True,
                  **kwargs
@@ -925,6 +927,8 @@ class BuildOptions:
         """Whether to consider insert and remove edits to lists"""
         self.allow_list_edits_when_same_length = allow_list_edits_when_same_length
         """Whether to consider insert and remove edits on lists that are the same length"""
+        self.auto_match_keys = auto_match_keys
+        """Whether to automatically match key/value pairs in dictionaries if they share the same key"""
         for attr, value in kwargs.items():
             setattr(self, attr, value)
 

--- a/graphtage/json.py
+++ b/graphtage/json.py
@@ -62,8 +62,10 @@ def build_tree(
             build_tree(k, options=options, force_leaf_node=True):
                 build_tree(v, options=options) for k, v in python_obj.items()
         }
-        if options is None or options.allow_key_edits:
-            return DictNode.from_dict(dict_items)
+        if options.allow_key_edits:
+            dict_node = DictNode.from_dict(dict_items)
+            dict_node.auto_match_keys = options.auto_match_keys
+            return dict_node
         else:
             return FixedKeyDictNode.from_dict(dict_items)
     elif python_obj is None:
@@ -255,7 +257,8 @@ class JSON(Filetype):
         try:
             return self.build_tree(path=path, options=options)
         except json.decoder.JSONDecodeError as de:
-            return f'Error parsing {os.path.basename(path)}: {de.msg}: line {de.lineno}, column {de.colno} (char {de.pos})'
+            return f'Error parsing {os.path.basename(path)}: {de.msg}: line {de.lineno}, column {de.colno} ' \
+                   f'(char {de.pos})'
 
     def get_default_formatter(self) -> JSONFormatter:
         return JSONFormatter.DEFAULT_INSTANCE

--- a/graphtage/version.py
+++ b/graphtage/version.py
@@ -59,7 +59,7 @@ If :const:`True`, the git branch will be included in the version string.
 """
 
 
-__version__: Tuple[Union[int, str], ...] = (0, 2, 7)
+__version__: Tuple[Union[int, str], ...] = (0, 2, 6)
 
 if DEV_BUILD:
     branch_name = git_branch()

--- a/graphtage/version.py
+++ b/graphtage/version.py
@@ -48,7 +48,7 @@ def git_branch() -> Optional[str]:
         return None
 
 
-DEV_BUILD = True
+DEV_BUILD = False
 """Sets whether this build is a development build.
 
 This should only be set to :const:`False` to coincide with a release. It should *always* be :const:`False` before
@@ -59,7 +59,7 @@ If :const:`True`, the git branch will be included in the version string.
 """
 
 
-__version__: Tuple[Union[int, str], ...] = (0, 2, 6)
+__version__: Tuple[Union[int, str], ...] = (0, 2, 7)
 
 if DEV_BUILD:
     branch_name = git_branch()

--- a/graphtage/version.py
+++ b/graphtage/version.py
@@ -48,7 +48,7 @@ def git_branch() -> Optional[str]:
         return None
 
 
-DEV_BUILD = False
+DEV_BUILD = True
 """Sets whether this build is a development build.
 
 This should only be set to :const:`False` to coincide with a release. It should *always* be :const:`False` before

--- a/graphtage/xml.py
+++ b/graphtage/xml.py
@@ -139,7 +139,8 @@ class XMLElement(ContainerNode):
             attrib: Optional[Dict[StringNode, StringNode]] = None,
             text: Optional[StringNode] = None,
             children: Sequence['XMLElement'] = (),
-            allow_key_edits: bool = True
+            allow_key_edits: bool = True,
+            auto_match_keys: bool = True
     ):
         """Initializes an XML element.
 
@@ -157,6 +158,7 @@ class XMLElement(ContainerNode):
             attrib = {}
         if allow_key_edits:
             self.attrib: DictNode = DictNode.from_dict(attrib)
+            self.attrib.auto_match_keys = auto_match_keys
             """The attributes of this element."""
         else:
             self.attrib = FixedKeyDictNode.from_dict(attrib)
@@ -263,7 +265,8 @@ def build_tree(
         },
         text=text,
         children=[build_tree(child, options) for child in root],
-        allow_key_edits=options is None or options.allow_key_edits
+        allow_key_edits=options is None or options.allow_key_edits,
+        auto_match_keys=options is None or options.auto_match_keys
     )
 
 


### PR DESCRIPTION
Take these two JSON files as an example:
```console
$ cat f1.json
{
    "foo": [1, 2, 3],
    "oof": [1, "two", 3]
}
$ cat f2.json
{
    "bar": [1, 2, 3],
    "foo": [1, "two", 3] 
}
```

By default Graphtage used to try all possible matchings between dictionary key/value pairs; comparing `graphtage f1.json f2.json` would result in the "foo" key being replaced by "bar" and the "f" in the "oof" key being moved to the front of the string.

This sort of matching is polynomial time in the size of the input, but often is still intractable for large files. Therefore, Graphtage had an option, `--no-key-edits` or `-k` that would prevent two dictionary key/value pairs from being compared to each other unless their keys were identical. `graphtage -k f1.json f2.json` would have resulted in the `2` being replaced by `"two"`, the entire "oof" key/value pair being removed, and the entire "foo" key/value pair being added.

This PR…
1. generalizes these two options with a new `--dict-strategy`/`-ds` option which sets the strategy: `match` for the old default behavior and `none` for the old `--no-key-edits` behavior. The `--no-key-edits` option still exists, but now is an alias to `--dict-strategy none`.
2. adds a new strategy, `--dict-strategy auto`, which is now the default, that behaves exactly the same as the `match` strategy, but in the event that two key/value pairs have then exact same key, then they are automatically matched.

`graphtage --dict-strategy auto f1.json f2.json` will now result in `2` being replaces with `"two"`, `oof` being replaced by `bar`, and `"two"` being replaced by `2`.