### PR TITLE
Fixes a bug in which pure Python object diffing could cause an infinite loop

### DIFF
--- a/graphtage/debug.py
+++ b/graphtage/debug.py
@@ -2,6 +2,7 @@
 Utilities to aid in debugging
 """
 
+from functools import partial
 from inspect import getmembers
 
 DEBUG_MODE = False
@@ -14,15 +15,25 @@ if DEBUG_MODE:
         def __new__(cls, *args, **kwargs):
             instance = super().__new__(cls)
             if not instance._DEBUG_PATCHED:
+                debug_all_member = None
                 for name, member in getmembers(instance):
                     if not name.startswith("_debug_"):
                         continue
                     name = name[len("_debug_"):]
-                    if not hasattr(instance, name):
+                    if name == "__all__":
+                        debug_all_member = member
+                        continue
+                    elif not hasattr(instance, name):
                         continue
                     func = getattr(instance, name)
                     setattr(instance, f"_original_{name}", func)
                     setattr(instance, name, member)
+                if debug_all_member is not None:
+                    for name, member in getmembers(instance):
+                        if name.startswith("_") or not callable(member):
+                            continue
+
+                        setattr(instance, name, partial(debug_all_member, name, member))
                 instance._DEBUG_PATCHED = True
             return instance
 else:

--- a/graphtage/debug.py
+++ b/graphtage/debug.py
@@ -1,0 +1,30 @@
+"""
+Utilities to aid in debugging
+"""
+
+from inspect import getmembers
+
+DEBUG_MODE = False
+
+
+if DEBUG_MODE:
+    class Debuggable:
+        _DEBUG_PATCHED: bool = False
+
+        def __new__(cls, *args, **kwargs):
+            instance = super().__new__(cls)
+            if not instance._DEBUG_PATCHED:
+                for name, member in getmembers(instance):
+                    if not name.startswith("_debug_"):
+                        continue
+                    name = name[len("_debug_"):]
+                    if not hasattr(instance, name):
+                        continue
+                    func = getattr(instance, name)
+                    setattr(instance, f"_original_{name}", func)
+                    setattr(instance, name, member)
+                instance._DEBUG_PATCHED = True
+            return instance
+else:
+    class Debuggable:
+        pass

--- a/graphtage/edits.py
+++ b/graphtage/edits.py
@@ -322,7 +322,7 @@ class Replace(ConstantCostEdit):
             with printer.bright().color(Fore.WHITE).background(Back.GREEN):
                 formatter.print(printer, self.to_node, False)
         else:
-            formatter.print(self.to_node, printer, False)
+            formatter.print(printer, self.to_node, False)
 
     def __repr__(self):
         return f"{self.__class__.__name__}(to_replace={self.from_node!r}, replace_with={self.to_node!r})"
@@ -422,7 +422,7 @@ class EditCollection(AbstractCompoundEdit, Generic[C]):
             cost_upper_bound += to_node.total_size
         self._cost = None
         self.explode_edits = explode_edits
-        self._add: Callable[[Edit], Any] = lambda e: add_to_collection(self._sub_edits, e)
+        self._add: Callable[[Edit], Any] = lambda e: add_to_collection(self._sub_edits, e)  # type: ignore
         super().__init__(from_node=from_node,
                          to_node=to_node,
                          cost_upper_bound=cost_upper_bound)

--- a/test/test_pydiff.py
+++ b/test/test_pydiff.py
@@ -1,7 +1,10 @@
+import dataclasses
 from unittest import TestCase
 
 import graphtage
 from graphtage.pydiff import build_tree, print_diff, PyDiffFormatter
+
+from .timing import run_with_time_limit
 
 
 class TestPyDiff(TestCase):
@@ -33,3 +36,13 @@ class TestPyDiff(TestCase):
         self.assertIsInstance(kvp, graphtage.KeyValuePairNode)
         self.assertIsInstance(kvp.key, graphtage.StringNode)
         self.assertIsInstance(kvp.value, graphtage.ListNode)
+
+    def test_infinite_loop(self):
+        """Reproduces https://github.com/trailofbits/graphtage/issues/82"""
+
+        @dataclasses.dataclass
+        class Thing:
+            foo: str
+
+        with run_with_time_limit(60):
+            _ = graphtage.pydiff.diff([Thing("ok")], [Thing("bad")])

--- a/test/test_timing.py
+++ b/test/test_timing.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from .timing import run_with_time_limit
+
+
+def infinite_loop():
+    while True:
+        pass
+
+
+def limited_infinite_loop():
+    with run_with_time_limit(seconds=1):
+        infinite_loop()
+
+
+class TestTiming(TestCase):
+    def test_time_limit(self):
+        self.assertRaises(TimeoutError, limited_infinite_loop)
+
+    def test_non_infinite_loop(self):
+        with run_with_time_limit(seconds=60):
+            _ = 10

--- a/test/timing.py
+++ b/test/timing.py
@@ -1,0 +1,18 @@
+import threading
+import _thread
+from contextlib import contextmanager
+
+
+@contextmanager
+def run_with_time_limit(seconds: int):
+    timer = threading.Timer(seconds, _thread.interrupt_main)
+    timer.start()
+
+    try:
+        yield
+        return
+    except:
+        pass
+    finally:
+        timer.cancel()
+    raise TimeoutError(f"timeout after {seconds} seconds")


### PR DESCRIPTION
For more information, see Issue #82.

The problem was that the `graphtage.pydiff.PyObjEdit` object did not properly override its superclass's `bounds()` member function.