### PR TITLE
Fix Python 3.12 compatibility by updating fickling requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     python_requires='>=3.8',
     install_requires=[
         "colorama",
-        "fickling>=0.0.8",
+        "fickling>=0.1.3",
         "intervaltree",
         "json5==0.9.5",
         "numpy>=1.19.4",


### PR DESCRIPTION
## Summary
This PR fixes Python 3.12 compatibility by updating the minimum required version of the `fickling` dependency.

## Problem
Python 3.12 removed the `distutils` module from the standard library, which caused graphtage to fail with the following error when importing fickling:
```
ModuleNotFoundError: No module named 'distutils'
```

## Solution
The fickling library already fixed this issue in version 0.1.3 by replacing distutils with the `stdlib-list` package (see trailofbits/fickling#103). This PR updates the minimum fickling version requirement from `>=0.0.8` to `>=0.1.3`.

## Changes
- Updated `setup.py` to require `fickling>=0.1.3` instead of `fickling>=0.0.8`

## Testing
- Verified that fickling 0.1.3+ can be imported without distutils errors
- The fix is minimal and only changes the version constraint for the problematic dependency

Closes #91