### PR TITLE
Add --no-unicode flag to disable combining marks in output

### DIFF
--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -113,6 +113,8 @@ def main(argv=None) -> int:
                             help='do not print a newline after each key/value pair in a dictionary')
     formatting.add_argument('--condensed', '-j', action='store_true', help='equivalent to `-jl -jd`')
     formatting.add_argument('--html', action='store_true', help='output the diff in HTML')
+    formatting.add_argument('--no-unicode', action='store_true',
+                            help='do not use Unicode combining marks in the output (only use colors)')
     key_match_strategy = parser.add_mutually_exclusive_group()
     key_match_strategy.add_argument("--dict-strategy", "-ds", choices=("auto", "match", "none"),
                                     help="sets the strategy for matching dictionary key/value pairs: `auto` (the "
@@ -206,7 +208,8 @@ def main(argv=None) -> int:
         options={
             'join_lists': args.condensed or args.join_lists,
             'join_dict_items': args.condensed or args.join_dict_items
-        }
+        },
+        enable_unicode=not args.no_unicode
     )
     printermodule.DEFAULT_PRINTER = printer
 

--- a/graphtage/printer.py
+++ b/graphtage/printer.py
@@ -450,7 +450,8 @@ class Printer(StatusWriter, RawWriter):
             out_stream: Optional[Writer] = None,
             ansi_color: Optional[bool] = None,
             quiet: bool = False,
-            options: Optional[Dict[str, Any]] = None
+            options: Optional[Dict[str, Any]] = None,
+            enable_unicode: bool = True
     ):
         """Initializes a Printer.
 
@@ -461,6 +462,8 @@ class Printer(StatusWriter, RawWriter):
             quiet: If :const:`True`, progress and status messages will be suppressed.
             options: An optional dict, the keys of which will be set as attributes of this class. This is used to
                 provide additional formatting options to functions that use this printer.
+            enable_unicode: Whether or not Unicode combining marks should be used in the output. If :const:`False`,
+                only ANSI colors will be used to highlight differences.
 
         """
         if out_stream is None:
@@ -472,6 +475,7 @@ class Printer(StatusWriter, RawWriter):
         self._context_type: Type[ANSIContext] = ANSIContext
         self.out_stream: CombiningMarkWriter = CombiningMarkWriter(self)
         """The stream wrapped by this printer."""
+        self.out_stream.enabled = enable_unicode
         self.indents: int = 0
         """The number of indent steps."""
         self.indent_str: str = ' ' * 4


### PR DESCRIPTION
This commit adds a new command-line flag `--no-unicode` that allows users to disable Unicode combining marks (strikethrough and underline characters) in the diff output while preserving ANSI color highlighting. This addresses the issue where the dual formatting (colors + unicode marks) creates difficulties when converting output to HTML and LaTeX formats.

The implementation:
- Adds `--no-unicode` flag to the argument parser in __main__.py
- Passes the `enable_unicode` parameter to the Printer constructor
- Sets the `CombiningMarkWriter.enabled` property based on user preference

When `--no-unicode` is specified, only ANSI colors are used to highlight additions (green) and deletions (red), making the output easier to process downstream while maintaining visual differentiation.

Fixes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)