### PR TITLE
Produce an edit when diffing a dictionary against a set

### DIFF
--- a/graphtage/graphtage.py
+++ b/graphtage/graphtage.py
@@ -217,9 +217,7 @@ class KeyValuePairNode(ContainerNode):
         return self.key, self.value
 
     def edits(self, node: TreeNode) -> Edit:
-        if not isinstance(node, KeyValuePairNode):
-            raise RuntimeError("KeyValuePairNode.edits() should only ever be called with another KeyValuePair object!")
-        if self.allow_key_edits or self.key == node.key:
+        if isinstance(node, KeyValuePairNode) and (self.allow_key_edits or self.key == node.key):
             return KeyValuePairEdit(self, node)
         else:
             return Replace(self, node)

--- a/graphtage/multiset.py
+++ b/graphtage/multiset.py
@@ -57,7 +57,7 @@ class MultiSetEdit(SequenceEdit):
                 if not isinstance(f, graphtage.KeyValuePairNode):
                     continue
                 for t in to_set.keys():
-                    if not isinstance(f, graphtage.KeyValuePairNode):
+                    if not isinstance(t, graphtage.KeyValuePairNode):
                         continue
                     if f.key == t.key:
                         num_matched = min(from_set[f], to_set[t])

--- a/test/test_multiset.py
+++ b/test/test_multiset.py
@@ -1,0 +1,58 @@
+from unittest import TestCase
+
+import graphtage
+from graphtage.builder import BasicBuilder
+from graphtage.multiset import MultiSetEdit
+from graphtage.pydiff import diff
+
+
+class TestMultiSetEdit(TestCase):
+    """Tests for matching one unordered collection against another.
+
+    :class:`graphtage.DictNode` is itself a :class:`graphtage.MultiSetNode`, so comparing a dictionary against a set
+    is routed through :class:`graphtage.multiset.MultiSetEdit`.
+
+    """
+
+    def assertMultiSetEdit(self, from_obj, to_obj, expected_cost: int) -> MultiSetEdit:
+        """Asserts that diffing two Python objects yields a multiset edit of the given cost."""
+        edit = BasicBuilder().build_tree(from_obj).edits(BasicBuilder().build_tree(to_obj))
+        self.assertIsInstance(edit, MultiSetEdit)
+        self.assertEqual(expected_cost, edit.bounds().lower_bound)
+        self.assertEqual(expected_cost, edit.bounds().upper_bound)
+        return edit
+
+    def test_dict_versus_set(self):
+        """A dictionary on the `from` side and a set on the `to` side used to raise an :class:`AttributeError`."""
+        self.assertMultiSetEdit({"a": 1}, {1, 2, 3}, 9)
+        self.assertEqual(9, diff({"a": 1}, {1, 2, 3}).edited_cost())
+
+    def test_dict_versus_set_of_tuples(self):
+        """Set members do not have to be leaves for the `to` side to contain no key/value pairs."""
+        self.assertMultiSetEdit({"a": 1}, {(1, 2), (3, 4)}, 10)
+
+    def test_set_versus_dict(self):
+        """This direction always worked, because the outer loop skips a `from` side that holds no key/value pairs."""
+        self.assertMultiSetEdit({1, 2, 3}, {"a": 1}, 9)
+
+    def test_dict_versus_dict_auto_matches_keys(self):
+        """Key/value pairs that share a key are matched up front, so neither is left to insert or remove.
+
+        Passing `auto_match_keys=False` leaves both of them in the symmetric difference, which is what makes this
+        an assertion about auto-matching rather than about the cost of the edit.
+
+        """
+        edit = self.assertMultiSetEdit({"a": 1}, {"a": 2}, 1)
+        self.assertEqual([], list(edit.to_insert.elements()))
+        self.assertEqual([], list(edit.to_remove.elements()))
+
+        options = graphtage.BuildOptions(auto_match_keys=False)
+        unmatched = BasicBuilder(options).build_tree({"a": 1}).edits(BasicBuilder(options).build_tree({"a": 2}))
+        self.assertEqual(1, len(list(unmatched.to_insert.elements())))
+        self.assertEqual(1, len(list(unmatched.to_remove.elements())))
+
+    def test_set_versus_set(self):
+        self.assertMultiSetEdit({1, 2, 3}, {1, 2, 4}, 1)
+
+    def test_dict_with_set_value(self):
+        self.assertMultiSetEdit({"a": {1, 2}}, {"a": {1, 3}}, 1)


### PR DESCRIPTION
Closes #126

Diffing a dictionary against a set raises `AttributeError` on `master` today. The issue has the reproducer, the cause, and the affected-case matrix; this PR fixes it and pins the behavior with tests.

No new features are involved. The bug was found while implementing #56.

## What the fix changes

**`graphtage/multiset.py:60`** — the inner loop over `to_set.keys()` re-tested `f` instead of `t`. The outer loop has already established that `f` is a `KeyValuePairNode`, so the inner guard never skipped anything and a `to` element without a `key` attribute reached `f.key == t.key`.

**`graphtage/graphtage.py:219-223`** — a second defect on the same path, which the issue does not cover. With the guard corrected, the auto-matching loop no longer crashes, but the bipartite matcher then asks a `KeyValuePairNode` to cost an edit against a non-pair node, and `KeyValuePairNode.edits` rejected that with a `RuntimeError`:

```
RuntimeError: KeyValuePairNode.edits() should only ever be called with another KeyValuePair object!
```

So the typo fix on its own turns an `AttributeError` into a `RuntimeError` and the comparison still fails. `Replace` is the correct edit for a key/value pair matched against a non-pair, and it is already what the reverse direction produces: `IntegerNode.edits(KeyValuePairNode)` falls through to `Replace`, which is the only reason `set` vs `dict` worked. With both fixes, the two directions agree — `{"a": 1}` against `{1, 2, 3}` costs 9 either way.

If you would rather keep the `RuntimeError` as an invariant check, the alternative is to narrow `DictNode.edits` to `isinstance(node, MappingNode)` so a dictionary compared against a plain multiset returns `Replace` at the top. That is a larger behavior change, and it leaves the two directions asymmetric, so this PR does not take that route.

## Tests

`test/test_multiset.py` covers the matrix from the issue. Verified against unpatched `master`:

| Test | On `master` | With the typo fix alone | With this PR |
| --- | --- | --- | --- |
| `test_dict_versus_set` | `AttributeError` | `RuntimeError` | passes |
| `test_dict_versus_set_of_tuples` | `AttributeError` | `RuntimeError` | passes |
| `test_set_versus_dict` | passes | passes | passes |
| `test_dict_versus_dict_auto_matches_keys` | passes | passes | passes |
| `test_set_versus_set` | passes | passes | passes |
| `test_dict_with_set_value` | passes | passes | passes |

The last four are regression guards for the cases the issue lists as already working. They pass on `master` by design: the fix changes which branch the auto-matching loop takes, so the point of those tests is to show that the branch it now takes does not change any of the results that were already correct.

`test_dict_versus_dict_auto_matches_keys` is the control. It asserts that `to_insert` and `to_remove` are both empty, which happens only when the two `"a"` pairs are matched up front, and it asserts that the same comparison with `auto_match_keys=False` leaves one node in each. Cost alone does not distinguish the two, because the bipartite matcher finds the same optimal matching either way, so a test that only checked the cost would still pass against a fix that disabled auto-matching.

Every assertion is on the resulting edit type and its bounds, not on the absence of an exception. Costs are stable under `PYTHONHASHSEED` (checked with 0, 1, 42, and 12345); the tests use sets of integers and tuples of integers, whose hashes are not randomized.

Full suite: 73 passed. `flake8 graphtage test --select=E9,F63,F7,F82` and `ruff check` report nothing new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
