### PR TITLE
Add a git diff driver and document git integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,95 @@ By default, Graphtage prints status messages and a progress bar to STDERR. To su
 option. To additionally suppress all but critical log messages, use `--quiet`. Fine-grained control of log messages is
 via the `--log-level` option.
 
+### Git Integration
+Graphtage installs a `graphtage-git-diff` command that implements git's external diff interface, so `git diff` can
+render changes to structured files semantically.
+
+Git passes a diff driver seven arguments: the path of the file in the repository, followed by the two revisions to
+compare along with their hashes and modes. At least one of those revisions is a temporary copy whose name does not
+necessarily carry the original file extension, and Graphtage detects file types from extensions, so
+`graphtage-git-diff` takes the file type from the repository path rather than from the files it compares.
+
+To set the driver up, define it in your git configuration:
+```console
+$ git config --global diff.graphtage.command graphtage-git-diff
+```
+Then assign it in `.gitattributes` to the file types you want Graphtage to handle:
+```console
+$ cat .gitattributes
+```
+```gitattributes
+*.json diff=graphtage
+*.yaml diff=graphtage
+```
+`git diff` now formats changes to those files with Graphtage:
+```console
+$ git diff
+```
+```json
+original.json
+{
+    "foo": [
+        ~~1~~,
+        2,
+        3,
+        4,
+        ++5++
+    ],
+    "++z++~~b~~a++b++~~r~~": "testing",
+    ++"woo": [
+        "foobar"
+    ]++
+}
+```
+```console
+$ git diff -- deploy.yaml
+```
+```yaml
+deploy.yaml
+name: graphtage
+ports: 
+- 8080
+- ++8443++
+replicas: 2 -> 5
+```
+
+Assign the driver only to extensions that Graphtage supports. Git stops a diff at the first file its driver fails on,
+so a driver assigned to every file fails as soon as it reaches one whose type Graphtage does not recognize.
+
+To try the driver without changing any configuration, set `GIT_EXTERNAL_DIFF` for a single command:
+```console
+$ GIT_EXTERNAL_DIFF=graphtage-git-diff git diff
+```
+
+`git log` and `git show` do not run external diff drivers unless you pass `--ext-diff`:
+```console
+$ git log --patch --ext-diff
+```
+
+To pass Graphtage options through the driver, add them to the command. Spell the value of each option with an equals
+sign, because git appends its own arguments and a value passed as a separate argument is indistinguishable from the
+first of them:
+```console
+$ git config --global diff.graphtage.command 'graphtage-git-diff --color --format=yaml'
+```
+Use `--color` or `-c` when git sends the diff to a pager. Graphtage suppresses the Unicode marks that distinguish
+the two sides of a change when its output is not a terminal, and a pager reads from a pipe. The marks survive the
+pipe, but the ANSI colors do not.
+
+Git stops the whole diff when a driver exits with a non-zero status, so `graphtage-git-diff` exits with a status of
+zero whether or not it finds differences. It reserves a non-zero status for failures that leave it with nothing to
+print, such as an unsupported file type or a file that does not parse. Graphtage compares two revisions, so the
+driver reports a file that a commit adds or deletes instead of diffing it.
+
+You can also run Graphtage from `git difftool`, which supplies the path of the file in `$MERGED` and the two
+revisions in `$LOCAL` and `$REMOTE`. `graphtage-git-diff` ignores the hash and mode arguments, so a `.` stands in for
+each of them:
+```console
+$ git config --global difftool.graphtage.cmd 'graphtage-git-diff "$MERGED" "$LOCAL" . . "$REMOTE" . .'
+$ git difftool --no-prompt --tool=graphtage
+```
+
 ## Why does Graphtage exist?
 
 Diffing tree-like structures with unordered elements is tough. Say you want to compare two JSON files.

--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -243,8 +243,8 @@ def main(argv=None) -> int:
         else:
             from_mime = None
 
-    if args.from_mime is not None:
-        to_mime = args.from_mime
+    if args.to_mime is not None:
+        to_mime = args.to_mime
     else:
         for typename in graphtage.FILETYPES_BY_TYPENAME.keys():
             to_mime = getattr(args, f'to_{typename}')

--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -37,6 +37,32 @@ class PathOrStdin:
             return self._tempfile.__exit__(*args, **kwargs)
 
 
+def register_mimetypes():
+    """Registers the MIME types of the file formats that Graphtage supports.
+
+    :func:`mimetypes.guess_type` does not know about several of the formats that Graphtage parses, and the types it
+    does know about vary between platforms. This adds the missing types without overriding any that the platform
+    already provides.
+    """
+    mimetypes.init()
+    if '.yml' not in mimetypes.types_map and '.yaml' not in mimetypes.types_map:
+        mimetypes.add_type('application/x-yaml', '.yml')
+        mimetypes.suffix_map['.yaml'] = '.yml'
+    elif '.yml' not in mimetypes.types_map:
+        mimetypes.suffix_map['.yml'] = '.yaml'
+    elif '.yaml' not in mimetypes.types_map:
+        mimetypes.suffix_map['.yaml'] = '.yml'
+    if '.json5' not in mimetypes.types_map:
+        mimetypes.add_type('application/json5', '.json5')
+    if '.toml' not in mimetypes.types_map:
+        mimetypes.add_type('application/toml', '.toml')
+    if '.plist' not in mimetypes.types_map:
+        mimetypes.add_type('application/x-plist', '.plist')
+    if '.pkl' not in mimetypes.types_map and '.pickle' not in mimetypes.types_map:
+        mimetypes.add_type('application/x-python-pickle', '.pkl')
+        mimetypes.suffix_map['.pickle'] = '.pkl'
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
         description='A diff utility for tree-like files such as JSON, XML, HTML, YAML, and CSV.'
@@ -215,23 +241,7 @@ def main(argv=None) -> int:
         quiet=args.no_status or args.quiet,
     ))
 
-    mimetypes.init()
-    if '.yml' not in mimetypes.types_map and '.yaml' not in mimetypes.types_map:
-        mimetypes.add_type('application/x-yaml', '.yml')
-        mimetypes.suffix_map['.yaml'] = '.yml'
-    elif '.yml' not in mimetypes.types_map:
-        mimetypes.suffix_map['.yml'] = '.yaml'
-    elif '.yaml' not in mimetypes.types_map:
-        mimetypes.suffix_map['.yaml'] = '.yml'
-    if '.json5' not in mimetypes.types_map:
-        mimetypes.add_type('application/json5', '.json5')
-    if '.toml' not in mimetypes.types_map:
-        mimetypes.add_type('application/toml', '.toml')
-    if '.plist' not in mimetypes.types_map:
-        mimetypes.add_type('application/x-plist', '.plist')
-    if '.pkl' not in mimetypes.types_map and '.pickle' not in mimetypes.types_map:
-        mimetypes.add_type('application/x-python-pickle', '.pkl')
-        mimetypes.suffix_map['.pickle'] = '.pkl'
+    register_mimetypes()
 
     if args.from_mime is not None:
         from_mime = args.from_mime

--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -17,6 +17,15 @@ from .utils import Tempfile
 
 log = logging.getLogger('graphtage')
 
+EXIT_SUCCESS = 0
+"""The exit status used when the two inputs are semantically identical."""
+
+EXIT_DIFFERENCES_FOUND = 1
+"""The exit status used when the two inputs differ."""
+
+EXIT_ERROR = 2
+"""The exit status used when Graphtage could not compute a diff."""
+
 
 class PathOrStdin:
     def __init__(self, path):
@@ -198,7 +207,7 @@ def main(argv=None) -> int:
         numeric_log_level = getattr(logging, args.log_level.upper(), None)
         if not isinstance(numeric_log_level, int):
             sys.stderr.write(f'Invalid log level: {args.log_level}')
-            exit(1)
+            exit(EXIT_ERROR)
 
     if args.dumpversion:
         print(' '.join(map(str, version.__version__)))
@@ -302,7 +311,7 @@ def main(argv=None) -> int:
                         to_format = graphtage.get_filetype(to_path, to_mime)
                     except ValueError as e:
                         sys.stderr.write(f"Error: {e!s}\n\n")
-                        return 1
+                        return EXIT_ERROR
                     with printer.tqdm(desc=f"Loading {from_path!s}", total=2, leave=False) as t:
                         from_tree = from_format.build_tree_handling_errors(from_path, options)
                         t.desc = f"Loading {to_path!s}"
@@ -310,13 +319,13 @@ def main(argv=None) -> int:
                         if isinstance(from_tree, str):
                             sys.stderr.write(from_tree)
                             sys.stderr.write('\n\n')
-                            return 1
+                            return EXIT_ERROR
                         to_tree = to_format.build_tree_handling_errors(to_path, options)
                         t.update(1)
                         if isinstance(to_tree, str):
                             sys.stderr.write(to_tree)
                             sys.stderr.write('\n\n')
-                            return 1
+                            return EXIT_ERROR
                     if match_if is not None or match_unless is not None:
                         for node in from_tree.dfs():
                             if match_if is not None:
@@ -359,9 +368,9 @@ def main(argv=None) -> int:
     finally:
         printer.close()
     if had_edits:
-        return 1
+        return EXIT_DIFFERENCES_FOUND
     else:
-        return 0
+        return EXIT_SUCCESS
 
 
 if __name__ == '__main__':

--- a/graphtage/git.py
+++ b/graphtage/git.py
@@ -1,0 +1,145 @@
+"""A ``git`` external diff driver that formats changes with Graphtage.
+
+Git runs an external diff driver with seven positional arguments::
+
+    path old-file old-hex old-mode new-file new-hex new-mode
+
+``old-file`` and ``new-file`` are the two revisions to compare. Git usually passes at least one of them as a
+temporary copy whose name does not necessarily carry the original file extension, so this driver resolves the file
+type from ``path``, which is the file's location in the repository. Git appends two more arguments when it detects
+a rename or a copy, and passes a single argument for an unmerged path; both forms are handled.
+
+Git stops the whole diff when a driver exits with a non-zero status, so this driver reports a successful diff as
+:const:`graphtage.__main__.EXIT_SUCCESS` even when the two revisions differ. A status of
+:const:`graphtage.__main__.EXIT_ERROR` is reserved for failures that prevent Graphtage from producing a diff at
+all, such as an unsupported file type or a file that does not parse.
+
+See the "Git Integration" section of the Graphtage README for the ``git`` configuration this driver expects.
+"""
+
+import os
+import sys
+from typing import List, Optional, Sequence, Tuple
+
+from . import graphtage
+from .__main__ import EXIT_DIFFERENCES_FOUND, EXIT_ERROR, EXIT_SUCCESS, register_mimetypes
+from .__main__ import main as graphtage_main
+
+UNMERGED_ARGUMENT_COUNT = 1
+"""The number of arguments git passes for an unmerged path."""
+
+DIFF_ARGUMENT_COUNTS = (7, 9)
+"""The number of arguments git passes for a changed path, without and with rename or copy detection."""
+
+ABSENT_FILE_NAMES = frozenset(('/dev/null', os.devnull))
+"""The names git uses in place of a revision that does not exist, such as when a file is added or deleted."""
+
+USAGE = """usage: graphtage-git-diff [GRAPHTAGE_OPTION...] PATH OLD_FILE OLD_HEX OLD_MODE NEW_FILE NEW_HEX NEW_MODE
+
+This command implements git's external diff interface, so git supplies the positional arguments. Any Graphtage
+options must come first and must spell values with an equals sign, as in `--format=yaml`. See the "Git Integration"
+section of the Graphtage README.
+"""
+
+
+def split_options(argv: Sequence[str]) -> Tuple[List[str], List[str]]:
+    """Splits the leading Graphtage options off of the arguments that git supplies.
+
+    Git appends its own positional arguments after whatever command the user configured, so every argument up to
+    the first one that does not start with ``-`` belongs to the user. Two consequences follow: an option that takes
+    a value must spell it with an equals sign, because a value passed as a separate argument is indistinguishable
+    from the first argument supplied by git, and a repository path that starts with ``-`` is read as an option.
+
+    Args:
+        argv: The command line arguments, excluding the name of the program.
+
+    Returns:
+        Tuple[List[str], List[str]]: The options to forward to Graphtage, followed by git's arguments.
+    """
+    index = 0
+    while index < len(argv) and argv[index].startswith('-'):
+        index += 1
+    return list(argv[:index]), list(argv[index:])
+
+
+def mime_options(path: str, forwarded: Sequence[str]) -> List[str]:
+    """Builds the Graphtage MIME type options implied by a path in the repository.
+
+    Args:
+        path: The path of the file in the repository, which git passes as its first argument.
+        forwarded: The Graphtage options that the user configured, which take precedence over the inferred type.
+
+    Returns:
+        List[str]: The ``--from-mime`` and ``--to-mime`` options that are not already covered by ``forwarded``.
+
+    Raises:
+        ValueError: If the file type of ``path`` is unknown or is not supported by Graphtage.
+    """
+    prefixes = [
+        prefix for prefix in ('--from-', '--to-')
+        if not any(option.startswith(prefix) for option in forwarded)
+    ]
+    if not prefixes:
+        return []
+    mime_type = graphtage.get_filetype(path).default_mimetype
+    return [f'{prefix}mime={mime_type}' for prefix in prefixes]
+
+
+def absent_revision(from_path: str, to_path: str) -> Optional[str]:
+    """Describes a change that leaves Graphtage with only one revision to work from.
+
+    Args:
+        from_path: The old revision, which git passes as its second argument.
+        to_path: The new revision, which git passes as its fifth argument.
+
+    Returns:
+        Optional[str]: ``'added'`` or ``'deleted'`` if one of the revisions is missing, and :const:`None` if both
+        of them exist.
+    """
+    if from_path in ABSENT_FILE_NAMES:
+        return 'added'
+    if to_path in ABSENT_FILE_NAMES:
+        return 'deleted'
+    return None
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Runs Graphtage over the two revisions that git supplies.
+
+    Args:
+        argv: The command line arguments, including the name of the program. Defaults to :data:`sys.argv`.
+
+    Returns:
+        int: :const:`graphtage.__main__.EXIT_SUCCESS` if the diff was produced, whether or not the revisions differ,
+        and :const:`graphtage.__main__.EXIT_ERROR` if Graphtage could not produce one.
+    """
+    if argv is None:
+        argv = sys.argv
+    forwarded, git_args = split_options(argv[1:])
+    if len(git_args) == UNMERGED_ARGUMENT_COUNT:
+        sys.stderr.write(f"graphtage: skipping unmerged path {git_args[0]}\n")
+        return EXIT_SUCCESS
+    if len(git_args) not in DIFF_ARGUMENT_COUNTS:
+        sys.stderr.write(USAGE)
+        return EXIT_ERROR
+    path, from_path, to_path = git_args[0], git_args[1], git_args[4]
+    sys.stdout.write(f"{path}\n")
+    change = absent_revision(from_path, to_path)
+    if change is not None:
+        sys.stdout.write(f"({change}; Graphtage compares two revisions and needs both of them)\n")
+        return EXIT_SUCCESS
+    register_mimetypes()
+    try:
+        inferred = mime_options(path, forwarded)
+    except ValueError as e:
+        sys.stderr.write(f"Error: {e!s}\n")
+        return EXIT_ERROR
+    sys.stdout.flush()
+    status = graphtage_main(['graphtage', '--no-status', *forwarded, *inferred, from_path, to_path])
+    if status == EXIT_DIFFERENCES_FOUND:
+        return EXIT_SUCCESS
+    return status
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
 
 [project.scripts]
 graphtage = "graphtage.__main__:main"
+graphtage-git-diff = "graphtage.git:main"
 
 [project.urls]
 Homepage = "https://github.com/trailofbits/graphtage"

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -1,0 +1,218 @@
+import contextlib
+import io
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from graphtage import git
+from graphtage.__main__ import EXIT_ERROR, EXIT_SUCCESS
+
+JSON_ONE = '{"foo": [1, 2, 3, 4], "bar": "testing"}\n'
+JSON_TWO = '{"foo": [2, 3, 4, 5], "bar": "testing"}\n'
+YAML_ONE = 'name: demo\nreplicas: 2\n'
+YAML_TWO = 'name: demo\nreplicas: 5\n'
+
+
+class GitDiffTestCase(unittest.TestCase):
+    """Base class providing a scratch directory and a helper for running the diff driver."""
+
+    def setUp(self):
+        self.directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.directory, True)
+
+    def write(self, name, contents):
+        """Writes a file into the scratch directory and returns its path."""
+        path = os.path.join(self.directory, name)
+        with open(path, 'w') as f:
+            f.write(contents)
+        return path
+
+    def run_driver(self, *argv):
+        """Runs the diff driver, returning its exit status and everything it wrote to STDOUT."""
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(io.StringIO()):
+            status = git.main(['graphtage-git-diff', *argv])
+        return status, out.getvalue()
+
+    def git_arguments(self, path, from_path, to_path):
+        """Builds the seven arguments git passes to an external diff driver.
+
+        The hash and mode arguments are deliberately nonsense so that a test fails if the driver ever reads them.
+        """
+        return [path, from_path, 'not-a-hash', 'not-a-mode', to_path, 'also-not-a-hash', 'also-not-a-mode']
+
+
+class TestSplitOptions(unittest.TestCase):
+    def test_no_options(self):
+        self.assertEqual(([], ['a.json', 'b', 'c']), git.split_options(['a.json', 'b', 'c']))
+
+    def test_leading_options_are_forwarded(self):
+        self.assertEqual(
+            (['--color', '--format=yaml'], ['a.json', 'b']),
+            git.split_options(['--color', '--format=yaml', 'a.json', 'b'])
+        )
+
+    def test_the_split_stops_at_the_first_positional(self):
+        """Only the leading run of options is forwarded, so later dashes stay with git's arguments."""
+        self.assertEqual(
+            (['-c'], ['conf.json', '--not-an-option', 'new']),
+            git.split_options(['-c', 'conf.json', '--not-an-option', 'new'])
+        )
+
+    def test_empty(self):
+        self.assertEqual(([], []), git.split_options([]))
+
+
+class TestMimeOptions(GitDiffTestCase):
+    def test_inferred_from_repository_path(self):
+        self.assertEqual(
+            ['--from-mime=application/json', '--to-mime=application/json'],
+            git.mime_options('src/conf.json', [])
+        )
+
+    def test_forwarded_options_take_precedence(self):
+        """An explicit type from the user must not collide with the inferred one."""
+        self.assertEqual(['--to-mime=application/json'], git.mime_options('conf.json', ['--from-json']))
+        self.assertEqual([], git.mime_options('conf.json', ['--from-mime=application/json', '--to-xml']))
+
+    def test_unsupported_type(self):
+        with self.assertRaises(ValueError):
+            git.mime_options('notes.txt', [])
+
+    def test_unknown_extension(self):
+        with self.assertRaises(ValueError):
+            git.mime_options('some-file-without-an-extension', [])
+
+
+class TestArgumentMapping(GitDiffTestCase):
+    def test_second_and_fifth_arguments_are_diffed(self):
+        """Git passes the old revision as its second argument and the new one as its fifth."""
+        one = self.write('one.json', JSON_ONE)
+        two = self.write('two.json', JSON_TWO)
+        status, output = self.run_driver(*self.git_arguments('conf.json', one, two))
+        self.assertEqual(EXIT_SUCCESS, status)
+        self.assertIn('conf.json', output)
+        self.assertIn('5', output)
+
+    def test_type_comes_from_the_repository_path(self):
+        """Git's temporary files may have no extension, so the type must come from the first argument."""
+        one = self.write('extensionless_one', YAML_ONE)
+        two = self.write('extensionless_two', YAML_TWO)
+        status, output = self.run_driver(*self.git_arguments('deploy/app.yaml', one, two))
+        self.assertEqual(EXIT_SUCCESS, status)
+        self.assertIn('replicas', output)
+
+    def test_rename_arguments_are_accepted(self):
+        """Git appends the new path and a similarity score when it detects a rename."""
+        one = self.write('one.json', JSON_ONE)
+        two = self.write('two.json', JSON_TWO)
+        arguments = [*self.git_arguments('old.json', one, two), 'new.json', 'similarity']
+        status, _ = self.run_driver(*arguments)
+        self.assertEqual(EXIT_SUCCESS, status)
+
+    def test_forwarded_options_reach_graphtage(self):
+        one = self.write('one.json', JSON_ONE)
+        two = self.write('two.json', JSON_TWO)
+        status, output = self.run_driver('--format=yaml', *self.git_arguments('conf.json', one, two))
+        self.assertEqual(EXIT_SUCCESS, status)
+        self.assertNotIn('{', output)
+
+    def test_unmerged_path(self):
+        """Git passes a single argument for an unmerged path, which the driver has nothing to diff."""
+        status, _ = self.run_driver('conf.json')
+        self.assertEqual(EXIT_SUCCESS, status)
+
+    def test_wrong_argument_count(self):
+        status, _ = self.run_driver('conf.json', 'one', 'two')
+        self.assertEqual(EXIT_ERROR, status)
+
+    def test_option_value_as_separate_argument_is_rejected(self):
+        """`--format yaml` leaves eight positional arguments, which cannot be git's."""
+        one = self.write('one.json', JSON_ONE)
+        two = self.write('two.json', JSON_TWO)
+        status, _ = self.run_driver('--format', 'yaml', *self.git_arguments('conf.json', one, two))
+        self.assertEqual(EXIT_ERROR, status)
+
+
+class TestExitStatus(GitDiffTestCase):
+    """Git stops the entire diff when a driver exits non-zero, so differences must not be reported as failure."""
+
+    def test_differences_are_not_an_error(self):
+        one = self.write('one.json', JSON_ONE)
+        two = self.write('two.json', JSON_TWO)
+        status, output = self.run_driver(*self.git_arguments('conf.json', one, two))
+        self.assertEqual(EXIT_SUCCESS, status)
+        self.assertIn('5', output)
+
+    def test_identical_revisions(self):
+        one = self.write('one.json', JSON_ONE)
+        two = self.write('two.json', JSON_ONE)
+        status, _ = self.run_driver(*self.git_arguments('conf.json', one, two))
+        self.assertEqual(EXIT_SUCCESS, status)
+
+    def test_added_file(self):
+        two = self.write('two.json', JSON_TWO)
+        status, output = self.run_driver(*self.git_arguments('conf.json', '/dev/null', two))
+        self.assertEqual(EXIT_SUCCESS, status)
+        self.assertIn('added', output)
+
+    def test_deleted_file(self):
+        one = self.write('one.json', JSON_ONE)
+        status, output = self.run_driver(*self.git_arguments('conf.json', one, '/dev/null'))
+        self.assertEqual(EXIT_SUCCESS, status)
+        self.assertIn('deleted', output)
+
+    def test_unsupported_type_is_an_error(self):
+        one = self.write('one.txt', 'hello\n')
+        two = self.write('two.txt', 'goodbye\n')
+        status, _ = self.run_driver(*self.git_arguments('notes.txt', one, two))
+        self.assertEqual(EXIT_ERROR, status)
+
+    def test_parse_failure_is_an_error(self):
+        one = self.write('one.json', JSON_ONE)
+        two = self.write('two.json', '{this is not json\n')
+        status, _ = self.run_driver(*self.git_arguments('conf.json', one, two))
+        self.assertEqual(EXIT_ERROR, status)
+
+
+class TestGitIntegration(unittest.TestCase):
+    """Runs the driver through a real `git diff` to confirm git accepts its output and exit status."""
+
+    def setUp(self):
+        if shutil.which('git') is None:
+            self.skipTest('git is not installed')
+        self.directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.directory, True)
+        self.git('init', '-q')
+        self.git('config', 'user.email', 'graphtage@example.com')
+        self.git('config', 'user.name', 'Graphtage')
+        self.git('config', 'commit.gpgsign', 'false')
+
+    def git(self, *arguments):
+        return subprocess.run(
+            ['git', '-C', self.directory, *arguments],
+            capture_output=True, text=True
+        )
+
+    def write(self, name, contents):
+        with open(os.path.join(self.directory, name), 'w') as f:
+            f.write(contents)
+
+    def test_git_accepts_the_driver(self):
+        self.write('conf.json', JSON_ONE)
+        self.git('add', '-A')
+        commit = self.git('commit', '-q', '-m', 'initial')
+        self.assertEqual(0, commit.returncode, commit.stderr)
+        self.write('conf.json', JSON_TWO)
+        driver = f'"{sys.executable}" -m graphtage.git'
+        environment = dict(os.environ, GIT_EXTERNAL_DIFF=driver)
+        result = subprocess.run(
+            ['git', '-C', self.directory, '--no-pager', 'diff'],
+            capture_output=True, text=True, env=environment
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn('conf.json', result.stdout)
+        self.assertIn('5', result.stdout)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,0 +1,61 @@
+import contextlib
+import io
+import os
+import shutil
+import tempfile
+import unittest
+
+from graphtage.__main__ import EXIT_DIFFERENCES_FOUND, EXIT_ERROR, EXIT_SUCCESS, main
+
+
+class TestCommandLine(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.directory, True)
+
+    def write(self, name, contents):
+        path = os.path.join(self.directory, name)
+        with open(path, 'w') as f:
+            f.write(contents)
+        return path
+
+    def run_graphtage(self, *arguments):
+        """Runs the command line interface, returning its exit status and everything it wrote to STDOUT."""
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(io.StringIO()):
+            status = main(['graphtage', '--no-status', *arguments])
+        return status, out.getvalue()
+
+    def test_to_mime_is_honored(self):
+        """`--to-mime` used to be discarded in favor of `--from-mime`, so the second file's type was guessed."""
+        from_path = self.write('one.json', '{"a": 1}\n')
+        to_path = self.write('two_without_an_extension', 'a: 2\n')
+        status, output = self.run_graphtage('--to-mime', 'application/x-yaml', from_path, to_path)
+        self.assertEqual(EXIT_DIFFERENCES_FOUND, status)
+        self.assertIn('2', output)
+
+    def test_from_mime_is_honored(self):
+        from_path = self.write('one_without_an_extension', 'a: 1\n')
+        to_path = self.write('two.json', '{"a": 2}\n')
+        status, output = self.run_graphtage('--from-mime', 'application/x-yaml', from_path, to_path)
+        self.assertEqual(EXIT_DIFFERENCES_FOUND, status)
+        self.assertIn('2', output)
+
+    def test_identical_files(self):
+        from_path = self.write('one.json', '{"a": 1}\n')
+        to_path = self.write('two.json', '{"a": 1}\n')
+        status, _ = self.run_graphtage(from_path, to_path)
+        self.assertEqual(EXIT_SUCCESS, status)
+
+    def test_undetectable_type_is_an_error(self):
+        """A failure to produce a diff is reported separately from having found differences."""
+        from_path = self.write('one', '{"a": 1}\n')
+        to_path = self.write('two', '{"a": 2}\n')
+        status, _ = self.run_graphtage(from_path, to_path)
+        self.assertEqual(EXIT_ERROR, status)
+
+    def test_parse_failure_is_an_error(self):
+        from_path = self.write('one.json', '{"a": 1}\n')
+        to_path = self.write('two.json', '{this is not json\n')
+        status, _ = self.run_graphtage(from_path, to_path)
+        self.assertEqual(EXIT_ERROR, status)


### PR DESCRIPTION
Closes #22

Adds a way to wire Graphtage into `git` without writing a shell wrapper, plus the documentation for doing it.

## The entry point

A new `graphtage-git-diff` console script (`graphtage/git.py`) implements git's external diff interface:

```
graphtage-git-diff [GRAPHTAGE_OPTION...] PATH OLD_FILE OLD_HEX OLD_MODE NEW_FILE NEW_HEX NEW_MODE
```

- It diffs git's second and fifth arguments and ignores the hash and mode arguments.
- It resolves the file type from `PATH`, the file's location in the repository, rather than from the files it is
  handed. Graphtage detects file types from extensions, and at least one of the two revisions is a temporary copy
  whose name does not necessarily carry the original extension.
- It passes `--no-status`.
- It accepts the seven arguments git passes for a changed path, the nine it passes when it detects a rename or a
  copy, and the single argument it passes for an unmerged path.
- Graphtage options placed before git's arguments are forwarded. Each value has to be spelled with an equals sign,
  as in `--format=yaml`, because a value passed as a separate argument is indistinguishable from the first argument
  git appends. An eight-argument invocation, which is what that mistake produces, reports a usage error.
- When a commit adds or deletes a file, git passes `/dev/null` for the missing side. The driver reports the change
  rather than trying to parse `/dev/null`.

## Exit statuses

Git calls `die("external diff died, stopping at %s")` for any non-zero status from a diff driver, which ends the
whole diff. Graphtage returns 1 when the two inputs differ, which for a diff driver is the ordinary case, so
`graphtage-git-diff` translates that to 0.

Swallowing every non-zero status would also hide real failures, and Graphtage returned 1 for those too. So this
branch separates them: an unsupported file type or a file that does not parse now returns 2, and 1 continues to
mean that the inputs differ. `graphtage-git-diff` passes 2 through, so git stops and reports the problem instead of
printing nothing for that file. This is a behavior change to the `graphtage` command itself; callers that test for
a non-zero status are unaffected, and callers that test for exactly 1 to detect differences become more accurate.

Because an unrecognized file type is a hard failure, the README recommends assigning the driver in `.gitattributes`
to the extensions Graphtage supports rather than setting it for every file.

## Separate `--to-mime` fix

`__main__.py` read `args.from_mime` where it needed `args.to_mime`, so `--to-mime` was discarded and the second
file's type always fell back to extension-based detection. The `--to-<typename>` shorthands were unaffected. This is
in its own commit, since the documented recipes depend on the second file's type being set explicitly.

## Tests

`test/test_git.py` covers argument mapping, the argument counts git uses, file type inference from the repository
path, option forwarding, and the exit statuses. `test/test_main.py` covers the exit statuses of the `graphtage`
command and the `--to-mime` regression. One test runs a real `git diff` through the driver and skips when git is not
installed.

Each test was checked against a deliberately broken implementation to confirm it fails. The documented recipes were
also run against git 2.55.0, including `git diff`, `GIT_EXTERNAL_DIFF`, the `.gitattributes` driver,
`git log --patch --ext-diff`, option forwarding, and `git difftool`.

## Note for a follow-up

`--no-status` does not suppress the "Diffing" progress bar. `tree.py`, `levenshtein.py`, and `json.py` bind
`DEFAULT_PRINTER` with `from .printer import DEFAULT_PRINTER` at import time, so the reassignment in
`__main__.py:246` never reaches them. That is a pre-existing bug and is not addressed here; the effect on the driver
is transient output on STDERR, which git does not capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
