### PR TITLE
Add --ignore-list-order

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ The `--no-list-edits` or `-l` option will not consider interstitial insertions a
 The `--no-list-edits-when-same-length` or `-ll` option is a less drastic version of `-l` that will behave normally for
 lists that are of different lengths but behave like `-l` for lists that are of the same length.
 
+The `--ignore-list-order` option matches the elements of a list as an unordered collection, so moving an element within
+a list is not an edit:
+```console
+$ graphtage --ignore-list-order original.json modified.json
+```
+Duplicate elements still count. With this option, `[1, 1, 2]` matches `[2, 1, 1]` but not `[1, 2, 2]`.
+
+This option applies to the lists of every format Graphtage reads, with two exceptions: the rows of a CSV file and the
+children of an XML or HTML element stay ordered. Those two node types ignore `--no-list-edits` as well.
+
+Two lists whose elements all match each other cost nothing to compare, however long they are. Comparing two lists that
+differ is more expensive than the ordered comparison, and grows faster: matching 30 dictionaries where every element
+differs took about 30 seconds in one measurement, against 0.7 seconds without the option. Graphtage logs a warning when
+a comparison is large enough for this to matter.
+
+`--ignore-list-order` cannot be combined with `--no-list-edits` or `--no-list-edits-when-same-length`, because those two
+options apply only to ordered lists.
+
 ### ANSI Color
 By default, Graphtage will only use ANSI color in its output if it is run from a TTY. If, for example, you would like
 to have Graphtage emit colorized output from a script or pipe, use the `--color` or `-c` argument. To disable color even

--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -141,6 +141,13 @@ def main(argv=None) -> int:
         action='store_true',
         help='do not consider removal and insertion when comparing lists that are the same length'
     )
+    list_edit_group.add_argument(
+        '--ignore-list-order',
+        action='store_true',
+        help='match the elements of a list as an unordered collection, so reordering a list is not an edit; '
+             'duplicate elements still count, and matching two lists that differ can be much slower than the '
+             'default'
+    )
     parser.add_argument(
         '--no-status',
         action='store_true',
@@ -279,7 +286,8 @@ def main(argv=None) -> int:
         allow_key_edits=allow_key_edits,
         auto_match_keys=auto_match_keys,
         allow_list_edits=not args.no_list_edits,
-        allow_list_edits_when_same_length=not args.no_list_edits_when_same_length
+        allow_list_edits_when_same_length=not args.no_list_edits_when_same_length,
+        ignore_list_order=args.ignore_list_order
     )
 
     try:

--- a/graphtage/builder.py
+++ b/graphtage/builder.py
@@ -6,9 +6,10 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, T
 
 from . import (
     BoolNode, BuildOptions, DictNode, FixedKeyDictNode, FloatNode, IntegerNode, LeafNode, ListNode, MultiSetNode,
-    NullNode, StringNode, TreeNode
+    NullNode, StringNode, TreeNode, UnorderedListNode
 )
 from .object_set import IdentityHash
+from .sequences import SequenceNode
 
 C = TypeVar("C")
 T = TypeVar("T")
@@ -234,7 +235,9 @@ class BasicBuilder(Builder):
 
     @Builder.builder(list)
     @Builder.builder(tuple)
-    def build_list(self, obj, children: List[TreeNode]) -> ListNode:
+    def build_list(self, obj, children: List[TreeNode]) -> SequenceNode:
+        if self.options.ignore_list_order:
+            return UnorderedListNode(children, auto_match_keys=self.options.auto_match_keys)
         return ListNode(
             children,
             allow_list_edits=self.options.allow_list_edits,

--- a/graphtage/graphtage.py
+++ b/graphtage/graphtage.py
@@ -1021,6 +1021,7 @@ class BuildOptions:
                  auto_match_keys=True,
                  allow_list_edits=True,
                  allow_list_edits_when_same_length=True,
+                 ignore_list_order=False,
                  check_for_cyces=True,
                  ignore_cycles=False,
                  printer=NULL_PRINTER,
@@ -1037,6 +1038,21 @@ class BuildOptions:
         """Whether to consider insert and remove edits to lists"""
         self.allow_list_edits_when_same_length = allow_list_edits_when_same_length
         """Whether to consider insert and remove edits on lists that are the same length"""
+        self.ignore_list_order = ignore_list_order
+        """Whether to match the elements of a list as an unordered collection
+
+        With this set, reordering a list costs nothing, because lists are built as
+        :class:`UnorderedListNode` instead of :class:`ListNode`. Duplicate elements still count, so ``[1, 1, 2]``
+        matches ``[2, 1, 1]`` but not ``[1, 2, 2]``.
+
+        Two lists whose elements are all equal match immediately, however long they are. Matching two lists that
+        differ is a bipartite matching over their symmetric difference, which grows much faster than the ordered
+        comparison: 30 dictionaries of which none match takes about 22 seconds, against 0.12 seconds by default.
+
+        This applies to every format that builds its lists through :func:`graphtage.json.build_tree`, which is all
+        of them except the rows of a CSV file and the children of an XML element.
+
+        """
         self.auto_match_keys = auto_match_keys
         """Whether to automatically match key/value pairs in dictionaries if they share the same key"""
         self.check_for_cycles = check_for_cyces

--- a/graphtage/graphtage.py
+++ b/graphtage/graphtage.py
@@ -403,6 +403,33 @@ class MultiSetNode(SequenceNode[HashableCounter[T]], Generic[T]):
         return f"{self.__class__.__name__}({list(self)!r})"
 
 
+class UnorderedListNode(MultiSetNode[T], Generic[T]):
+    """A list whose elements are matched as an unordered collection.
+
+    This is the node type that :attr:`BuildOptions.ignore_list_order` builds in place of :class:`ListNode`. It keeps
+    the rendering of a list in every output format while inheriting the matching semantics of :class:`MultiSetNode`,
+    so reordering a list costs nothing. Duplicate elements still count: ``[1, 1, 2]`` matches ``[2, 1, 1]`` for free,
+    but not ``[1, 2, 2]``.
+
+    """
+
+    def to_obj(self):
+        return [n.to_obj() for n in self]
+
+    def edits(self, node: TreeNode) -> Edit:
+        if isinstance(node, MappingNode):
+            return Replace(self, node)
+        elif isinstance(node, MultiSetNode):
+            return super().edits(node)
+        elif isinstance(node, ListNode):
+            other = HashableCounter(node._children)
+            if self._children == other:
+                return Match(self, node, 0)
+            return MultiSetEdit(self, node, self._children, other, auto_match_keys=self.auto_match_keys)
+        else:
+            return Replace(self, node)
+
+
 class MappingNode(ContainerNode, ABC):
     """An abstract base class for nodes that represent mappings."""
 
@@ -524,7 +551,7 @@ class DictNode(MappingNode, MultiSetNode[KeyValuePairNode]):
         )
 
     def edits(self, node: TreeNode) -> Edit:
-        if isinstance(node, MultiSetNode):
+        if isinstance(node, MultiSetNode) and not isinstance(node, UnorderedListNode):
             return super().edits(node)
         else:
             return Replace(self, node)

--- a/graphtage/graphtage.py
+++ b/graphtage/graphtage.py
@@ -1045,9 +1045,10 @@ class BuildOptions:
         :class:`UnorderedListNode` instead of :class:`ListNode`. Duplicate elements still count, so ``[1, 1, 2]``
         matches ``[2, 1, 1]`` but not ``[1, 2, 2]``.
 
-        Two lists whose elements are all equal match immediately, however long they are. Matching two lists that
-        differ is a bipartite matching over their symmetric difference, which grows much faster than the ordered
-        comparison: 30 dictionaries of which none match takes about 22 seconds, against 0.12 seconds by default.
+        Two lists whose elements are all equal match immediately, however long they are: a shuffle of 2000 integers
+        takes about 0.01 seconds. Matching two lists that differ is a bipartite matching over their symmetric
+        difference, which grows much faster than the ordered comparison: 30 dictionaries of which none match took
+        about 30 seconds in one measurement, against 0.7 seconds by default.
 
         This applies to every format that builds its lists through :func:`graphtage.json.build_tree`, which is all
         of them except the rows of a CSV file and the children of an XML element.

--- a/graphtage/json.py
+++ b/graphtage/json.py
@@ -104,6 +104,8 @@ class JSONListFormatter(SequenceFormatter):
         """
         super().print_SequenceNode(*args, **kwargs)
 
+    print_UnorderedListNode = print_ListNode
+
     def print_SequenceNode(self, *args, **kwargs):
         """Prints a non-List sequence.
 

--- a/graphtage/json.py
+++ b/graphtage/json.py
@@ -11,7 +11,8 @@ import os
 from typing import Optional, Union
 
 from .graphtage import BoolNode, BuildOptions, DictNode, Filetype, FixedKeyDictNode, \
-    FloatNode, IntegerNode, KeyValuePairNode, LeafNode, ListNode, NullNode, StringFormatter, StringNode
+    FloatNode, IntegerNode, KeyValuePairNode, LeafNode, ListNode, NullNode, StringFormatter, StringNode, \
+    UnorderedListNode
 from .printer import DEFAULT_PRINTER, Fore, Printer
 from .sequences import SequenceFormatter
 from .tree import ContainerNode, GraphtageFormatter, TreeNode
@@ -52,9 +53,14 @@ def build_tree(
     elif force_leaf_node:
         raise ValueError(f"{python_obj!r} was expected to be an int or string, but was instead a {type(python_obj)}")
     elif isinstance(python_obj, list) or isinstance(python_obj, tuple):
+        children = [
+            build_tree(n, options=options) for n in
+            DEFAULT_PRINTER.tqdm(python_obj, delay=2.0, desc="Loading JSON List", leave=False)
+        ]
+        if options.ignore_list_order:
+            return UnorderedListNode(children, auto_match_keys=options.auto_match_keys)
         return ListNode(
-            [build_tree(n, options=options) for n in
-             DEFAULT_PRINTER.tqdm(python_obj, delay=2.0, desc="Loading JSON List", leave=False)],
+            children,
             allow_list_edits=options.allow_list_edits,
             allow_list_edits_when_same_length=options.allow_list_edits_when_same_length
         )

--- a/graphtage/multiset.py
+++ b/graphtage/multiset.py
@@ -5,6 +5,7 @@ This is used by :class:`graphtage.MultiSetNode` and :class:`graphtage.DictNode`,
 
 """
 
+import logging
 from typing import Iterator, List
 
 import graphtage
@@ -14,6 +15,11 @@ from .matching import WeightedBipartiteMatcher
 from .sequences import SequenceEdit, SequenceNode
 from .tree import Edit, TreeNode
 from .utils import HashableCounter, largest
+
+log = logging.getLogger(__name__)
+
+MATCHING_SIZE_WARNING_THRESHOLD = 400
+"""The number of candidate pairs above which matching two unordered collections is reported as slow."""
 
 
 class MultiSetEdit(SequenceEdit):
@@ -75,6 +81,12 @@ class MultiSetEdit(SequenceEdit):
         self.to_remove = from_set - to_set
         """The set of nodes in :obj:`from_set` that do not exist in :obj:`to_set`."""
         to_match = from_set & to_set
+        num_pairs = sum(self.to_remove.values()) * sum(self.to_insert.values())
+        if num_pairs > MATCHING_SIZE_WARNING_THRESHOLD:
+            log.warning(
+                "Matching %d unordered elements against %d requires costing %d pairs, which can take a long time",
+                sum(self.to_remove.values()), sum(self.to_insert.values()), num_pairs
+            )
         self._edits: List[Edit] = [Match(n, n, 0) for n in to_match.elements()]
         self._matcher = WeightedBipartiteMatcher(
             from_nodes=self.to_remove.elements(),

--- a/graphtage/plist.py
+++ b/graphtage/plist.py
@@ -71,6 +71,8 @@ class PLISTSequenceFormatter(SequenceFormatter):
         super().print_SequenceNode(printer, *args, **kwargs)
         printer.write("</array>")
 
+    print_UnorderedListNode = print_ListNode
+
     def print_MultiSetNode(self, printer: Printer, *args, **kwargs):
         printer.write("<dict>")
         super().print_SequenceNode(printer, *args, **kwargs)

--- a/graphtage/pydiff.py
+++ b/graphtage/pydiff.py
@@ -147,7 +147,16 @@ class ASTBuilder(BasicBuilder):
     @Builder.builder(ast.List)
     @Builder.builder(ast.Tuple)
     def build_ast_list(self, node: ast.List, children):
-        return self.build_list(node, children)
+        """Builds an ordered list, ignoring :attr:`BuildOptions.ignore_list_order`.
+
+        The elements of a Python list or tuple literal are positional, so reordering them is a change to the source.
+
+        """
+        return ListNode(
+            children,
+            allow_list_edits=self.options.allow_list_edits,
+            allow_list_edits_when_same_length=self.options.allow_list_edits_when_same_length
+        )
 
     @Builder.expander(ast.Assign)
     def expand_assign(self, node: ast.Assign):

--- a/graphtage/toml.py
+++ b/graphtage/toml.py
@@ -43,6 +43,8 @@ class TOMLListFormatter(SequenceFormatter):
         """
         super().print_SequenceNode(*args, **kwargs)
 
+    print_UnorderedListNode = print_ListNode
+
     def print_SequenceNode(self, *args, **kwargs):
         """Prints a non-List sequence.
 

--- a/graphtage/xml.py
+++ b/graphtage/xml.py
@@ -309,6 +309,8 @@ class XMLChildFormatter(SequenceFormatter):
     def print_ListNode(self, *args, **kwargs):
         super().print_SequenceNode(*args, **kwargs)
 
+    print_UnorderedListNode = print_ListNode
+
 
 class XMLElementAttribFormatter(SequenceFormatter):
     is_partial = True

--- a/graphtage/yaml.py
+++ b/graphtage/yaml.py
@@ -45,6 +45,8 @@ class YAMLListFormatter(SequenceFormatter):
         printer.newline()
         super().print_SequenceNode(printer, *args, **kwargs)
 
+    print_UnorderedListNode = print_ListNode
+
     def edit_print(self, printer: Printer, edit: Edit):
         printer.indents += 1
         self.print(printer, edit)

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -1,7 +1,7 @@
 from typing import List
 from unittest import TestCase
 
-from graphtage import IntegerNode, ListNode, TreeNode
+from graphtage import BuildOptions, IntegerNode, ListNode, TreeNode, UnorderedListNode
 from graphtage.builder import BasicBuilder, Builder
 
 
@@ -10,6 +10,13 @@ class TestBuilder(TestCase):
         result = BasicBuilder().build_tree([1, "a", (2, "b"), {1, 2}, {"a": "b"}, None])
         self.assertIsInstance(result, ListNode)
         self.assertEqual(6, len(result.children()))
+
+    def test_ignore_list_order(self):
+        options = BuildOptions(ignore_list_order=True)
+        result = BasicBuilder(options).build_tree([1, 2, 3])
+        self.assertIsInstance(result, UnorderedListNode)
+        self.assertEqual(3, len(result.children()))
+        self.assertEqual([1, 2, 3], result.to_obj())
 
     def test_custom_builder(self):
         test = self

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -198,6 +198,36 @@ class TestFormatting(TestCase):
             if not hasattr(self, f'test_{name}_formatting'):
                 self.fail(f"Filetype {name} is missing a `test_{name}_formatting` test function")
 
+    @staticmethod
+    def render(formatter: graphtage.GraphtageFormatter, node: graphtage.TreeNode) -> str:
+        stream = StringIO()
+        printer = graphtage.printer.Printer(out_stream=stream, ansi_color=False)
+        formatter.print(printer, node)
+        return stream.getvalue()
+
+    def test_unordered_list_renders_like_a_list(self):
+        """An :class:`graphtage.UnorderedListNode` must print exactly as the equivalent list in every format.
+
+        It is a :class:`graphtage.MultiSetNode`, so without a `print_UnorderedListNode` on each format's list
+        formatter it resolves to that format's dictionary formatter instead.
+
+        """
+        def make(node_type):
+            return node_type([graphtage.IntegerNode(i) for i in (1, 2, 3)])
+
+        for name, filetype in graphtage.FILETYPES_BY_TYPENAME.items():
+            formatter = filetype.get_default_formatter()
+            self.assertEqual(
+                self.render(formatter, make(graphtage.ListNode)),
+                self.render(formatter, make(graphtage.UnorderedListNode)),
+                f"{name} renders an UnorderedListNode differently from a ListNode"
+            )
+
+    def test_unordered_list_yaml_round_trip(self):
+        formatter = graphtage.FILETYPES_BY_TYPENAME["yaml"].get_default_formatter()
+        rendered = self.render(formatter, graphtage.UnorderedListNode([graphtage.IntegerNode(i) for i in (1, 2, 3)]))
+        self.assertEqual([1, 2, 3], yaml.safe_load(rendered))
+
     @filetype_test
     def test_json_formatting(self):
         orig_obj = TestFormatting.make_random_obj(force_string_keys=True)

--- a/test/test_graphtage.py
+++ b/test/test_graphtage.py
@@ -1,3 +1,4 @@
+import random
 from io import StringIO
 from unittest import TestCase
 
@@ -7,6 +8,16 @@ import graphtage.multiset
 import graphtage.tree
 
 from graphtage.printer import Printer
+
+from .timing import run_with_time_limit
+
+
+def unordered(*values) -> graphtage.UnorderedListNode:
+    return graphtage.UnorderedListNode([graphtage.IntegerNode(v) for v in values])
+
+
+def ordered(*values) -> graphtage.ListNode:
+    return graphtage.ListNode([graphtage.IntegerNode(v) for v in values])
 
 
 class TestGraphtage(TestCase):
@@ -110,3 +121,67 @@ class TestGraphtage(TestCase):
         self.assertIsInstance(diff, graphtage.tree.EditedTreeNode)
         self.assertEqual(1, len(diff.edit_list))
         self.assertIsInstance(diff.edit_list[0], graphtage.FixedLengthSequenceEdit)
+
+
+class TestUnorderedListNode(TestCase):
+    def test_ordered_list_reorder_costs(self):
+        """Reordering an ordinary list is an edit; this is what :class:`graphtage.UnorderedListNode` changes."""
+        edit = ordered(1, 2, 3).edits(ordered(3, 2, 1))
+        self.assertIsInstance(edit, graphtage.EditDistance)
+        self.assertEqual(4, ordered(1, 2, 3).diff(ordered(3, 2, 1)).edited_cost())
+
+    def test_reorder_is_free(self):
+        edit = unordered(1, 2, 3).edits(unordered(3, 2, 1))
+        self.assertIsInstance(edit, graphtage.Match)
+        self.assertEqual(0, edit.bounds().upper_bound)
+        self.assertEqual(0, unordered(1, 2, 3).diff(unordered(3, 2, 1)).edited_cost())
+
+    def test_reorder_against_an_ordered_list(self):
+        """Only one side has to ignore order, which is what makes cross-format comparisons work."""
+        self.assertIsInstance(unordered(1, 2, 3).edits(ordered(3, 2, 1)), graphtage.Match)
+        self.assertEqual(0, unordered(1, 2, 3).edits(ordered(3, 2, 1)).bounds().upper_bound)
+
+    def test_reorder_with_a_change(self):
+        edit = unordered(1, 2, 3).edits(unordered(3, 9, 1))
+        self.assertIsInstance(edit, graphtage.multiset.MultiSetEdit)
+        self.assertEqual(1, edit.bounds().upper_bound)
+
+    def test_duplicates_are_counted(self):
+        self.assertIsInstance(unordered(1, 1, 2).edits(unordered(2, 1, 1)), graphtage.Match)
+        self.assertEqual(0, unordered(1, 1, 2).edits(unordered(2, 1, 1)).bounds().upper_bound)
+        self.assertGreater(unordered(1, 1, 2).diff(unordered(1, 2, 2)).edited_cost(), 0)
+
+    def test_nested_lists(self):
+        from_node = graphtage.UnorderedListNode([unordered(1, 2), unordered(3, 4)])
+        to_node = graphtage.UnorderedListNode([unordered(4, 3), unordered(2, 1)])
+        edit = from_node.edits(to_node)
+        self.assertIsInstance(edit, graphtage.Match)
+        self.assertEqual(0, edit.bounds().upper_bound)
+
+    def test_versus_dict(self):
+        """A list is never matched against a dictionary, whether or not its order is ignored."""
+        dict_node = graphtage.DictNode.from_dict({graphtage.StringNode("a"): graphtage.IntegerNode(1)})
+        self.assertIsInstance(unordered(1, 2, 3).edits(dict_node), graphtage.Replace)
+        self.assertIsInstance(dict_node.edits(unordered(1, 2, 3)), graphtage.Replace)
+
+    def test_to_obj_of_unhashable_children(self):
+        """:meth:`graphtage.MultiSetNode.to_obj` counts its children, which fails for a list of dictionaries."""
+        def children():
+            return [
+                graphtage.DictNode.from_dict({graphtage.StringNode("a"): graphtage.IntegerNode(1)}),
+                graphtage.DictNode.from_dict({graphtage.StringNode("b"): graphtage.IntegerNode(2)}),
+            ]
+
+        self.assertEqual([{"a": 1}, {"b": 2}], graphtage.UnorderedListNode(children()).to_obj())
+        with self.assertRaises(TypeError):
+            graphtage.MultiSetNode(children()).to_obj()
+
+    def test_large_shuffle_is_fast(self):
+        """Equal multisets short-circuit to a match, so a big shuffle must not reach the bipartite matcher."""
+        values = list(range(1000))
+        shuffled = list(values)
+        random.Random(56).shuffle(shuffled)
+        with run_with_time_limit(seconds=30):
+            edit = unordered(*values).edits(unordered(*shuffled))
+        self.assertIsInstance(edit, graphtage.Match)
+        self.assertEqual(0, edit.bounds().upper_bound)

--- a/test/test_issue_56.py
+++ b/test/test_issue_56.py
@@ -1,0 +1,65 @@
+from unittest import TestCase
+
+import graphtage
+import graphtage.yaml
+from graphtage.utils import Tempfile
+
+RULES = b"""- macro: never_true
+  condition: (evt.num=0)
+
+- macro: always_true
+  condition: (evt.num>=0)
+
+- macro: spawned_process
+  condition: evt.type in (execve, execveat) and evt.dir=<
+
+- rule: ls run
+  desc: ls run
+  condition: spawned_process and proc.name=ls
+  output: ls run
+  priority: INFO
+  tags: [process]
+"""
+
+REORDERED_RULES = b"""- macro: never_true
+  condition: (evt.num=0)
+
+- macro: always_true
+  condition: (evt.num>=0)
+
+- rule: ls run
+  desc: ls run
+  condition: spawned_process and proc.name=ls
+  output: ls run
+  priority: INFO
+  tags: [process]
+
+- macro: spawned_process
+  condition: evt.type in (execve, execveat) and evt.dir=<
+"""
+
+
+class TestIssue56(TestCase):
+    """Reproduces https://github.com/trailofbits/graphtage/issues/56"""
+
+    @staticmethod
+    def build(content: bytes, options: graphtage.BuildOptions) -> graphtage.TreeNode:
+        with Tempfile(content) as path:
+            return graphtage.FILETYPES_BY_TYPENAME["yaml"].build_tree(path, options=options)
+
+    def diff(self, options: graphtage.BuildOptions):
+        return self.build(RULES, options).diff(self.build(REORDERED_RULES, options))
+
+    def test_reordered_documents_are_an_edit_by_default(self):
+        self.assertGreater(self.diff(graphtage.BuildOptions()).edited_cost(), 0)
+
+    def test_reordered_documents_match_when_ignoring_list_order(self):
+        """The two files differ only in where one document sits, so `graphtage` must report no change.
+
+        The second assertion mirrors how `graphtage.__main__` decides its exit status, so this is also an
+        assertion that the command exits 0.
+
+        """
+        diff = self.diff(graphtage.BuildOptions(ignore_list_order=True))
+        self.assertEqual(0, diff.edited_cost())
+        self.assertFalse(any(any(e.has_non_zero_cost() for e in n.edit_list) for n in diff.dfs()))

--- a/test/test_pydiff.py
+++ b/test/test_pydiff.py
@@ -1,8 +1,9 @@
+import ast
 import dataclasses
 from unittest import TestCase
 
 import graphtage
-from graphtage.pydiff import build_tree, print_diff, PyDiffFormatter
+from graphtage.pydiff import ast_to_tree, build_tree, print_diff, PyDiffFormatter
 
 from .timing import run_with_time_limit
 
@@ -11,6 +12,15 @@ class TestPyDiff(TestCase):
     def test_build_tree(self):
         self.assertIsInstance(build_tree([1, 2, 3, 4]), graphtage.ListNode)
         self.assertIsInstance(build_tree({1: 2, 'a': 'b'}), graphtage.DictNode)
+
+    def test_python_list_literals_stay_ordered(self):
+        """Elements of a Python list literal are positional, so `ignore_list_order` must not apply to them."""
+        options = graphtage.BuildOptions(ignore_list_order=True)
+        tree = ast_to_tree(ast.parse("x = [1, 2, 3]"), options)
+        lists = [n for n in tree.dfs() if isinstance(n, graphtage.ListNode)]
+        self.assertTrue(lists)
+        for node in tree.dfs():
+            self.assertNotIsInstance(node, graphtage.UnorderedListNode)
 
     def test_diff(self):
         t1 = [1, 2, {3: "three"}, 4]


### PR DESCRIPTION
Closes #56

Adds `--ignore-list-order`, and `BuildOptions.ignore_list_order` behind it, which matches the elements of a list as an unordered collection. The two YAML files from the issue now diff as no change, and `graphtage --ignore-list-order` exits 0 for them.

## Approach

`MultiSetNode` and `MultiSetEdit` already give order-insensitive matching, and `MultiSetNode.edits` short-circuits to a zero-cost `Match` when the two counters are equal. The obstacle was rendering: a `MultiSetNode` resolves to each format's *dictionary* formatter, so JSON emitted `{1, 2, 3}`, YAML dropped its `- ` bullets, plist emitted `<dict>`, and TOML raised a `RecursionError`.

`UnorderedListNode(MultiSetNode)` plus one alias per format's list formatter fixes that. Formatter dispatch walks the node type's MRO in the outer loop and the formatter tree in the inner loop, so `print_UnorderedListNode` on a list formatter wins over `print_MultiSetNode` on a dictionary formatter. `test_unordered_list_renders_like_a_list` asserts byte-identical output against the equivalent `ListNode` for all nine registered filetypes; CSV needed no alias and the test pins that it stays that way.

`to_obj` is overridden because `MultiSetNode.to_obj` builds a counter of its children's `to_obj()`, which raises `TypeError: unhashable type: 'dict'` for a list of dictionaries — and the issue's own reproducer is a list of dictionaries.

`graphtage.json.build_tree` is the chokepoint every filetype's lists pass through, so the option is read there and in `BasicBuilder.build_list`.

## Second pre-existing bug

`DictNode.edits` dispatched on `isinstance(node, MultiSetNode)`, and `UnorderedListNode` is one, so a dictionary on the `from` side would have produced a multiset edit against a list. It now excludes `UnorderedListNode`, which makes both directions agree on `Replace`, matching what an ordinary `ListNode` already does.

A separate pre-existing bug — the `multiset.py` auto-matching typo, plus `KeyValuePairNode.edits` raising rather than returning `Replace` for a non-pair node — turned up while implementing this and shipped on its own in #127, which is now merged. This branch is rebased on top of it.

## Deliberately left ordered

- `string_edit_distance` — character order is the semantics.
- `ASTBuilder.build_ast_list` — it delegated to `BasicBuilder.build_list` and now builds a `ListNode` itself, because the elements of a Python list or tuple literal are positional. `Module` and `CallArguments` in `graphtage.ast` are unchanged for the same reason.
- `PyObjBuilder`'s dataclass fields, which are blocked by the annotation type checks in `graphtage/dataclasses.py`.

## Out of scope

`csv.py` builds its `CSVRow` and `CSVNode` directly, and `xml.py` builds `XMLElementChildren` directly. Neither passes any build options, so both already ignore `--no-list-edits` — a pre-existing gap, not one this PR introduces. CSV rows and XML element children therefore stay ordered, which the README says. The XML formatter alias is still included so that rendering a JSON diff with `--format xml` does not regress.

## Performance

Measured on this branch:

| Comparison | Default | `--ignore-list-order` |
| --- | --- | --- |
| 2000 integers, pure shuffle | — | 0.01s |
| 30 dictionaries, every element different | 0.7s | 30s |

Equal multisets hit the counter fast path, so a pure reordering is free however long the list. Lists that differ go through a bipartite matching over the symmetric difference, and the matcher builds a dense cost matrix, so the cost is super-quadratic in the number of elements that do not match.

There is no hard cap and no automatic fallback: `--dict-strategy match` already ships with the same profile, and the contract is expensive but correct. `MultiSetEdit` logs a warning when the number of candidate pairs crosses 400, so the CLI says why it is slow rather than appearing to hang.

## Testing

88 tests pass, on Python 3.8.20 and 3.13.13. `flake8 graphtage test --select=E9,F63,F7,F82` is clean, `ruff check graphtage test` reports the same 205 findings as `master`, and `cd docs && make html` builds with the option documented on `BuildOptions`.

Each new test was checked against the unpatched code:

- Removing the `to_obj` override makes `test_to_obj_of_unhashable_children` fail with `TypeError`.
- Removing the `DictNode.edits` exclusion makes `test_versus_dict` fail.
- Removing the five formatter aliases makes `test_unordered_list_renders_like_a_list` fail on eight of the nine filetypes, and `test_unordered_list_yaml_round_trip` fail.
- Restoring `ASTBuilder.build_ast_list`'s delegation makes `test_python_list_literals_stay_ordered` fail.

`test_large_shuffle_is_fast` shuffles 1000 elements inside a 30-second limit, so a regression that loses the counter fast path fails rather than hangs.

## Worth filing separately

- `print_MultiSetNode` lives on each format's dictionary formatter, so a plain Python set still renders as `{1, 2, 3}` in JSON, which is not valid JSON. Relocating it is a separate change with its own compatibility question.
- `csv.py` and `xml.py` pass no build options to the list nodes they construct, so `--no-list-edits`, `--no-list-edits-when-same-length`, and now `--ignore-list-order` all have no effect on CSV rows or XML element children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
