### PR TITLE
Make --no-status and --quiet suppress the progress bar

### DIFF
--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -252,7 +252,7 @@ def main(argv=None) -> int:
             'join_dict_items': args.condensed or args.join_dict_items
         }
     )
-    printermodule.DEFAULT_PRINTER = printer
+    printermodule.set_default_printer(printer)
 
     logging.basicConfig(level=numeric_log_level, stream=Printer(
         sys.stderr,

--- a/graphtage/json.py
+++ b/graphtage/json.py
@@ -13,7 +13,7 @@ from typing import Optional, Union
 from .graphtage import BoolNode, BuildOptions, DictNode, Filetype, FixedKeyDictNode, \
     FloatNode, IntegerNode, KeyValuePairNode, LeafNode, ListNode, NullNode, StringFormatter, StringNode, \
     UnorderedListNode
-from .printer import DEFAULT_PRINTER, Fore, Printer
+from .printer import Fore, get_default_printer, Printer
 from .sequences import SequenceFormatter
 from .tree import ContainerNode, GraphtageFormatter, TreeNode
 
@@ -55,7 +55,7 @@ def build_tree(
     elif isinstance(python_obj, list) or isinstance(python_obj, tuple):
         children = [
             build_tree(n, options=options) for n in
-            DEFAULT_PRINTER.tqdm(python_obj, delay=2.0, desc="Loading JSON List", leave=False)
+            get_default_printer().tqdm(python_obj, delay=2.0, desc="Loading JSON List", leave=False)
         ]
         if options.ignore_list_order:
             return UnorderedListNode(children, auto_match_keys=options.auto_match_keys)
@@ -68,7 +68,7 @@ def build_tree(
         dict_items = {
             build_tree(k, options=options, force_leaf_node=True):
                 build_tree(v, options=options) for k, v in
-            DEFAULT_PRINTER.tqdm(python_obj.items(), delay=2.0, desc="Loading JSON Dict", leave=False)
+            get_default_printer().tqdm(python_obj.items(), delay=2.0, desc="Loading JSON Dict", leave=False)
         }
         if options.allow_key_edits:
             dict_node = DictNode.from_dict(dict_items)

--- a/graphtage/levenshtein.py
+++ b/graphtage/levenshtein.py
@@ -23,7 +23,7 @@ import numpy as np
 from .bounds import make_distinct, Range
 from .edits import Insert, Match, Remove
 from .fibonacci import FibonacciHeap
-from .printer import DEFAULT_PRINTER
+from .printer import get_default_printer
 from .sequences import SequenceEdit
 from .tree import Edit, TreeNode
 
@@ -271,8 +271,9 @@ class EditDistance(SequenceEdit):
                 fringe_ranges = {}
                 fringe_total = 0
                 num_diagonals = 0
+                printer = get_default_printer()
 
-                if not DEFAULT_PRINTER.quiet:
+                if not printer.quiet:
                     fringe_ranges = {
                         (row, col): (
                             self.edit_matrix[row][col].bounds().upper_bound
@@ -283,7 +284,7 @@ class EditDistance(SequenceEdit):
                     fringe_total = sum(fringe_ranges.values())
                     num_diagonals = len(self.from_seq) + len(self.to_seq)
 
-                with DEFAULT_PRINTER.tqdm(
+                with printer.tqdm(
                         total=fringe_total,
                         initial=0,
                         desc=f"Tightening Fringe Diagonal {self._fringe_row + self._fringe_col} of {num_diagonals}",

--- a/graphtage/printer.py
+++ b/graphtage/printer.py
@@ -9,7 +9,8 @@ There are several reasons for using this abstraction when printing in Graphtage:
    the command line).
 
 Attributes:
-    DEFAULT_PRINTER (Printer): A default :class:`Printer` instance printing to :attr:`sys.stdout`.
+    DEFAULT_PRINTER (Printer): A default :class:`Printer` instance printing to :attr:`sys.stdout`. Read it through
+        :func:`get_default_printer` rather than importing the name, because :func:`set_default_printer` replaces it.
 
 """
 
@@ -668,6 +669,34 @@ class HTMLPrinter(Printer):
 
 
 DEFAULT_PRINTER: Printer = Printer()
+
+
+def get_default_printer() -> Printer:
+    """Returns the printer that library code uses when the caller does not supply one.
+
+    Call this instead of importing :attr:`DEFAULT_PRINTER` by name. :func:`set_default_printer` rebinds the module
+    attribute, which a name bound by ``from .printer import DEFAULT_PRINTER`` never observes: such a name keeps
+    referring to the printer that was current when the importing module was first loaded.
+
+    Returns:
+        Printer: The printer most recently passed to :func:`set_default_printer`, or :attr:`DEFAULT_PRINTER` if that
+        function was never called.
+
+    """
+    return DEFAULT_PRINTER
+
+
+def set_default_printer(printer: Printer):
+    """Installs :obj:`printer` as the printer returned by :func:`get_default_printer`.
+
+    This mutates global state, so call it from an application entry point rather than from library code.
+
+    Args:
+        printer: The printer to install.
+
+    """
+    global DEFAULT_PRINTER
+    DEFAULT_PRINTER = printer
 
 
 class NullWriter(Writer):

--- a/graphtage/tree.py
+++ b/graphtage/tree.py
@@ -10,7 +10,7 @@ from typing_extensions import Protocol, runtime_checkable
 
 from .bounds import Bounded, Range
 from .formatter import Formatter, FORMATTERS
-from .printer import DEFAULT_PRINTER, Printer
+from .printer import get_default_printer, Printer
 
 log = logging.getLogger(__name__)
 
@@ -542,7 +542,7 @@ class TreeNode(metaclass=TreeNodeMeta):
         prev_bounds = edit.bounds()
         total_range = prev_bounds.upper_bound - prev_bounds.lower_bound
         prev_range = total_range
-        with DEFAULT_PRINTER.tqdm(leave=False, initial=0, total=total_range, desc='Diffing') as t:
+        with get_default_printer().tqdm(leave=False, initial=0, total=total_range, desc='Diffing') as t:
             while edit.valid and not edit.is_complete() and edit.tighten_bounds():
                 new_bounds = edit.bounds()
                 new_range = new_bounds.upper_bound - new_bounds.lower_bound
@@ -592,7 +592,7 @@ class TreeNode(metaclass=TreeNodeMeta):
         prev_bounds = edit.bounds()
         total_range = prev_bounds.upper_bound - prev_bounds.lower_bound
         prev_range = total_range
-        with DEFAULT_PRINTER.tqdm(leave=False, initial=0, total=total_range, desc='Diffing') as t:
+        with get_default_printer().tqdm(leave=False, initial=0, total=total_range, desc='Diffing') as t:
             while edit.valid and not edit.is_complete() and edit.tighten_bounds():
                 new_bounds = edit.bounds()
                 new_range = new_bounds.upper_bound - new_bounds.lower_bound

--- a/test/test_progress.py
+++ b/test/test_progress.py
@@ -1,0 +1,87 @@
+import json
+import subprocess
+import sys
+import tempfile
+from io import StringIO
+from os.path import join
+from typing import List, Tuple
+from unittest import TestCase
+
+import graphtage.json
+import graphtage.levenshtein
+import graphtage.tree
+from graphtage import printer
+from graphtage.printer import Printer
+
+FROM_OBJ = {"a": 1, "b": [1, 2, 3], "c": {"d": "hello world"}}
+TO_OBJ = {"a": 2, "b": [1, 2, 4], "c": {"d": "goodbye world"}}
+
+PROGRESS_BAR = b"Diffing:"
+
+
+def run_graphtage(*args: str) -> Tuple[bytes, bytes]:
+    """Runs the command line in a subprocess and returns what it wrote to stdout and to stderr.
+
+    The subprocess matters: the modules that draw the progress bars resolve the default printer while they are being
+    imported, so an in-process test would reuse whichever printer an earlier test installed.
+
+    Args:
+        *args: Options to pass before the two file operands.
+
+    Returns:
+        Tuple[bytes, bytes]: The bytes written to stdout and to stderr.
+
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        paths: List[str] = []
+        for name, obj in (("from.json", FROM_OBJ), ("to.json", TO_OBJ)):
+            path = join(tmpdir, name)
+            with open(path, "w") as f:
+                f.write(json.dumps(obj))
+            paths.append(path)
+        command: List[str] = [sys.executable, "-m", "graphtage"]
+        command.extend(args)
+        command.extend(paths)
+        result = subprocess.run(command, capture_output=True)
+    if result.returncode not in (0, 1):
+        raise AssertionError(f"`graphtage` exited with status {result.returncode}: {result.stderr.decode('utf-8')}")
+    return result.stdout, result.stderr
+
+
+class TestProgress(TestCase):
+    def test_progress_is_shown_by_default(self):
+        """Without a suppression flag, the diff draws its progress bar on stderr."""
+        _, stderr = run_graphtage()
+        self.assertIn(PROGRESS_BAR, stderr)
+
+    def test_no_status_suppresses_progress(self):
+        """``--no-status`` must leave stderr empty, as :file:`README.md` documents."""
+        stdout, stderr = run_graphtage("--no-status")
+        self.assertEqual(b"", stderr, f"`--no-status` wrote {len(stderr)} bytes to stderr")
+        self.assertIn(b'"a"', stdout)
+
+    def test_quiet_suppresses_progress(self):
+        """``--quiet`` must suppress the progress bar along with the log messages."""
+        stdout, stderr = run_graphtage("--quiet")
+        self.assertEqual(b"", stderr, f"`--quiet` wrote {len(stderr)} bytes to stderr")
+        self.assertIn(b'"a"', stdout)
+
+    def test_replacement_printer_reaches_every_progress_bar(self):
+        """Every module that draws a progress bar must observe :func:`graphtage.printer.set_default_printer`.
+
+        A module that binds ``DEFAULT_PRINTER`` at import time keeps the printer that was current when it was first
+        imported, which is what let the suppression flags be ignored.
+
+        """
+        replacement = Printer(out_stream=StringIO(), quiet=True)
+        original = printer.get_default_printer()
+        printer.set_default_printer(replacement)
+        try:
+            for module in (graphtage.json, graphtage.levenshtein, graphtage.tree):
+                self.assertIs(
+                    module.get_default_printer(),
+                    replacement,
+                    f"{module.__name__} did not observe the replacement printer",
+                )
+        finally:
+            printer.set_default_printer(original)


### PR DESCRIPTION
Closes #133

## Problem

`--no-status` and `--quiet` do not suppress the "Diffing" progress bar, contrary to what `README.md` documents.

## Root cause

`main()` builds a printer from the command line options and replaces the module attribute:

```python
printermodule.DEFAULT_PRINTER = printer
```

Three modules bind the name at import time instead of reading it through the module:

- `graphtage/tree.py` — `from .printer import DEFAULT_PRINTER, Printer`
- `graphtage/json.py` — `from .printer import DEFAULT_PRINTER, Fore, Printer`
- `graphtage/levenshtein.py` — `from .printer import DEFAULT_PRINTER`

Rebinding `printermodule.DEFAULT_PRINTER` leaves those names pointing at the printer that was current when each module was first imported, whose `quiet` is `False`. Their six `tqdm` call sites therefore draw progress bars whatever the flags say. The bar in the issue's reproducer comes from `tree.py`.

## Approach

`printer.py` gains `get_default_printer()` and `set_default_printer()`, and the three modules call the accessor at the point of use rather than binding the name. `main()` installs its printer through `set_default_printer()`.

The accessor resolves the printer when the progress bar is created, so the result no longer depends on which module Python imported first. That is what makes this different from a fix that only works today: any future module can call `get_default_printer()` without having to reason about import order, and adding another `from .printer import DEFAULT_PRINTER` is now a visible departure from the convention rather than an invisible one.

`DEFAULT_PRINTER` stays as the module attribute and remains the single source of truth, so `printer.DEFAULT_PRINTER` (used in `docs/library.rst`) keeps working. `set_default_printer()` gives the mutation a documented home instead of leaving it as a bare assignment in `main()`.

I considered plumbing the printer through explicitly. `BuildOptions` already carries a `printer` attribute, which would cover the two build-time bars in `json.py`, but the diff-time bars in `tree.py` and `levenshtein.py` sit on `TreeNode.diff()` and inside `EditDistance.tighten_bounds()`. Threading a printer to those would change the `TreeNode` and `Edit` signatures across the package, which is out of proportion to the bug.

`levenshtein.py` reads the printer once into a local and uses it for both the `quiet` guard and the `tqdm` call, so the guard and the bar can no longer disagree.

## Verification

The reproducer from the issue, on merged master (06e0417) and on this branch, with stderr redirected to a file:

| command | master | this branch |
|---|---|---|
| `graphtage big1.json big2.json` | 414 bytes | 414 bytes |
| `graphtage --no-status big1.json big2.json` | 101 bytes | 0 bytes |
| `graphtage --quiet big1.json big2.json` | 101 bytes | 0 bytes |

Default output is byte-for-byte unchanged.

Because tqdm is created with `disable=False` rather than `disable=None`, the bars are drawn whether or not stderr is a terminal, so a redirected run is not enough on its own to show that the default still works. I also ran the three cases with stdout and stderr each attached to a real pty sized 100x40:

| command | master stderr | this branch stderr |
|---|---|---|
| default | 402 bytes, bar present | 402 bytes, bar present |
| `--no-status` | 201 bytes, bar present | 0 bytes |
| `--quiet` | 201 bytes, bar present | 0 bytes |

stdout was identical (23302 bytes) in all six runs.

## Tests

`test/test_progress.py` adds four tests. Three run the command line in a subprocess, which is what the bug requires: the stale binding is established while the module is imported, so an in-process test would reuse whichever printer an earlier test had installed. The fourth asserts that all three modules observe `set_default_printer()`, which fails if anyone reintroduces an import-time binding.

Against merged master with the source changes reverted, three of the four fail:

```
FAILED test/test_progress.py::TestProgress::test_no_status_suppresses_progress
FAILED test/test_progress.py::TestProgress::test_quiet_suppresses_progress
FAILED test/test_progress.py::TestProgress::test_replacement_printer_reaches_every_progress_bar
3 failed, 1 passed
```

The one that passes is `test_progress_is_shown_by_default`, which is correct: this change does not alter default behavior.

With the fix applied, all four pass. Full suite: 123 passed on Python 3.14 and on Python 3.8. `ruff check` reports the same 27 pre-existing findings on the touched files before and after, and none on the new test file. `flake8 --select=E9,F63,F7,F82` is clean and `cd docs && make html` succeeds with the same five pre-existing warnings.

## Interaction with #130

This branch is rebased on master after #130, #129, and #131 merged. #130's changes are orthogonal: it moved `colorama.init()` into `enable_ansi_support()` and changed `NullWriter.isatty()` to return `False`, neither of which touches how `DEFAULT_PRINTER` is looked up. I re-confirmed the reproducer against merged master before finishing the fix; #130 did not incidentally address it. The rebase produced one conflict, in `json.py`, where #131 restructured the same `ListNode`/`UnorderedListNode` branch that holds one of the `tqdm` calls; it is resolved to keep both changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
