### PR TITLE
Fix exponential multiset equality and make slow fuzz iterations visible

### DIFF
--- a/graphtage/utils.py
+++ b/graphtage/utils.py
@@ -71,6 +71,32 @@ class HashableCounter(Generic[T], typing.Counter[T], Counter):
             h ^= hash((key, value))
         return h
 
+    def __eq__(self, other):
+        """Tests multiset equality with a single lookup per element.
+
+        :meth:`collections.Counter.__eq__` iterates over the elements of *both* counters, so it looks up every
+        element once in each direction. When the elements are themselves trees whose equality recurses into
+        nested counters, each level of nesting compares its children twice, which makes the comparison
+        exponential in the nesting depth. Probing only one side is linear in the total number of elements.
+
+        Args:
+            other: The object to compare against.
+
+        Returns:
+            bool: :const:`True` if every element has the same count in both counters, treating missing counts as
+            zero, exactly as :class:`collections.Counter` does.
+
+        """
+        if self is other:
+            return True
+        elif not isinstance(other, Counter):
+            return NotImplemented
+        our_elements = sum(1 for count in self.values() if count)
+        their_elements = sum(1 for count in other.values() if count)
+        if our_elements != their_elements:
+            return False
+        return all(other.get(element, 0) == count for element, count in self.items() if count)
+
     def elements(self) -> Iterator:
         """Iterator over elements repeating each as many times as its count.
 

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -60,7 +60,7 @@ RUN_SEED: int = _resolve_run_seed()
 """The seed for this run. Every random document is derived from it, so setting it replays the whole run."""
 
 
-def _resolve_filetype(name: str) -> Tuple[str, graphtage.Filetype]:
+def _resolve_filetype(name: str) -> graphtage.Filetype:
     """Returns the filetype that a test function named ``test_<filetype>_formatting`` exercises."""
     if not name.startswith(FILETYPE_TEST_PREFIX):
         raise ValueError(f'@filetype_test {name} must start with "{FILETYPE_TEST_PREFIX}"')
@@ -71,12 +71,12 @@ def _resolve_filetype(name: str) -> Tuple[str, graphtage.Filetype]:
         raise ValueError(
             f'Filetype "{filetype_name}" for @filetype_test {name} not found in graphtage.FILETYPES_BY_TYPENAME'
         )
-    return filetype_name, graphtage.FILETYPES_BY_TYPENAME[filetype_name]
+    return graphtage.FILETYPES_BY_TYPENAME[filetype_name]
 
 
-def _round_trip(self: 'TestFormatting', filetype, formatter, test_func, *, test_equality: bool):
+def _round_trip(test_case: 'TestFormatting', filetype, formatter, test_func, *, test_equality: bool):
     """Builds one random document, formats it, reparses the result, and checks that nothing was lost."""
-    orig_obj, representation = test_func(self)
+    orig_obj, representation = test_func(test_case)
     if isinstance(representation, str):
         representation = representation.encode("utf-8")
     with graphtage.utils.Tempfile(representation) as t:
@@ -89,14 +89,14 @@ def _round_trip(self: 'TestFormatting', filetype, formatter, test_func, *, test_
         try:
             new_obj = filetype.build_tree(t)
         except Exception as e:
-            self.fail(f"""{filetype.name.upper()} decode error {e}: Original object:
+            test_case.fail(f"""{filetype.name.upper()} decode error {e}: Original object:
 {orig_obj!r}
 Expected format:
 {representation.decode("utf-8")}
 Actual format:
 {formatted_str!s}""")
     if test_equality:
-        self.assertEqual(tree, new_obj)
+        test_case.assertEqual(tree, new_obj)
 
 
 def filetype_test(test_func=None, *, test_equality: bool = True, iterations: int = 1000):
@@ -105,12 +105,12 @@ def filetype_test(test_func=None, *, test_equality: bool = True, iterations: int
 
     @wraps(test_func)
     def wrapper(self: 'TestFormatting'):
-        filetype_name, filetype = _resolve_filetype(test_func.__name__)
+        filetype = _resolve_filetype(test_func.__name__)
         formatter = filetype.get_default_formatter()
         print(f'{test_func.__name__}: {SEED_ENVIRONMENT_VARIABLE}={RUN_SEED}')
 
         for iteration in trange(iterations):
-            random.seed(f'{RUN_SEED}:{filetype_name}:{iteration}')
+            random.seed(f'{RUN_SEED}:{filetype.name}:{iteration}')
             try:
                 with run_with_time_limit(ITERATION_TIME_LIMIT_SECONDS):
                     _round_trip(self, filetype, formatter, test_func, test_equality=test_equality)

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -1,11 +1,14 @@
 import csv
 import json
+import os
 import plistlib
 import random
+import time
 from functools import partial, wraps
 from io import StringIO
 from typing import FrozenSet, Optional, Tuple, Type, Union
 from unittest import TestCase
+from unittest.mock import patch
 
 import toml
 import yaml
@@ -13,6 +16,8 @@ from tqdm import trange
 
 import graphtage
 from graphtage import xml
+
+from .timing import run_with_time_limit
 
 
 STR_BYTES: FrozenSet[str] = frozenset([
@@ -27,6 +32,72 @@ LETTERS: Tuple[str, ...] = tuple(
 FILETYPE_TEST_PREFIX = 'test_'
 FILETYPE_TEST_SUFFIX = '_formatting'
 
+SEED_ENVIRONMENT_VARIABLE = 'GRAPHTAGE_TEST_SEED'
+"""The environment variable that replays a previous run's random documents."""
+
+ITERATION_TIME_LIMIT_SECONDS = 30
+"""The wall-clock budget for a single fuzzing iteration.
+
+A healthy iteration takes well under a second on the documents these generators produce, so an iteration that
+approaches this budget is a performance bug rather than an unlucky draw. Failing at the budget keeps a
+pathological document visible and reproducible instead of letting it stall the job for hours.
+
+"""
+
+
+def _resolve_run_seed() -> int:
+    """Returns the seed for this run, taken from :data:`SEED_ENVIRONMENT_VARIABLE` when it is set."""
+    configured = os.environ.get(SEED_ENVIRONMENT_VARIABLE)
+    if configured is None:
+        return random.randrange(2 ** 32)
+    try:
+        return int(configured)
+    except ValueError:
+        raise ValueError(f'{SEED_ENVIRONMENT_VARIABLE} must be an integer, not {configured!r}')
+
+
+RUN_SEED: int = _resolve_run_seed()
+"""The seed for this run. Every random document is derived from it, so setting it replays the whole run."""
+
+
+def _resolve_filetype(name: str) -> Tuple[str, graphtage.Filetype]:
+    """Returns the filetype that a test function named ``test_<filetype>_formatting`` exercises."""
+    if not name.startswith(FILETYPE_TEST_PREFIX):
+        raise ValueError(f'@filetype_test {name} must start with "{FILETYPE_TEST_PREFIX}"')
+    elif not name.endswith(FILETYPE_TEST_SUFFIX):
+        raise ValueError(f'@filetype_test {name} must end with "{FILETYPE_TEST_SUFFIX}"')
+    filetype_name = name[len(FILETYPE_TEST_PREFIX):-len(FILETYPE_TEST_SUFFIX)]
+    if filetype_name not in graphtage.FILETYPES_BY_TYPENAME:
+        raise ValueError(
+            f'Filetype "{filetype_name}" for @filetype_test {name} not found in graphtage.FILETYPES_BY_TYPENAME'
+        )
+    return filetype_name, graphtage.FILETYPES_BY_TYPENAME[filetype_name]
+
+
+def _round_trip(self: 'TestFormatting', filetype, formatter, test_func, *, test_equality: bool):
+    """Builds one random document, formats it, reparses the result, and checks that nothing was lost."""
+    orig_obj, representation = test_func(self)
+    if isinstance(representation, str):
+        representation = representation.encode("utf-8")
+    with graphtage.utils.Tempfile(representation) as t:
+        tree = filetype.build_tree(t)
+        stream = StringIO()
+        printer = graphtage.printer.Printer(out_stream=stream, ansi_color=False)
+        formatter.print(printer, tree)
+        formatted_str = stream.getvalue()
+    with graphtage.utils.Tempfile(formatted_str.encode('utf-8')) as t:
+        try:
+            new_obj = filetype.build_tree(t)
+        except Exception as e:
+            self.fail(f"""{filetype.name.upper()} decode error {e}: Original object:
+{orig_obj!r}
+Expected format:
+{representation.decode("utf-8")}
+Actual format:
+{formatted_str!s}""")
+    if test_equality:
+        self.assertEqual(tree, new_obj)
+
 
 def filetype_test(test_func=None, *, test_equality: bool = True, iterations: int = 1000):
     if test_func is None:
@@ -34,39 +105,22 @@ def filetype_test(test_func=None, *, test_equality: bool = True, iterations: int
 
     @wraps(test_func)
     def wrapper(self: 'TestFormatting'):
-        name = test_func.__name__
-        if not name.startswith(FILETYPE_TEST_PREFIX):
-            raise ValueError(f'@filetype_test {name} must start with "{FILETYPE_TEST_PREFIX}"')
-        elif not name.endswith(FILETYPE_TEST_SUFFIX):
-            raise ValueError(f'@filetype_test {name} must end with "{FILETYPE_TEST_SUFFIX}"')
-        filetype_name = name[len(FILETYPE_TEST_PREFIX):-len(FILETYPE_TEST_SUFFIX)]
-        if filetype_name not in graphtage.FILETYPES_BY_TYPENAME:
-            raise ValueError(f'Filetype "{filetype_name}" for @filetype_test {name} not found in graphtage.FILETYPES_BY_TYPENAME')
-        filetype = graphtage.FILETYPES_BY_TYPENAME[filetype_name]
+        filetype_name, filetype = _resolve_filetype(test_func.__name__)
         formatter = filetype.get_default_formatter()
+        print(f'{test_func.__name__}: {SEED_ENVIRONMENT_VARIABLE}={RUN_SEED}')
 
-        for _ in trange(iterations):
-            orig_obj, representation = test_func(self)
-            if isinstance(representation, str):
-                representation = representation.encode("utf-8")
-            with graphtage.utils.Tempfile(representation) as t:
-                tree = filetype.build_tree(t)
-                stream = StringIO()
-                printer = graphtage.printer.Printer(out_stream=stream, ansi_color=False)
-                formatter.print(printer, tree)
-                formatted_str = stream.getvalue()
-            with graphtage.utils.Tempfile(formatted_str.encode('utf-8')) as t:
-                try:
-                    new_obj = filetype.build_tree(t)
-                except Exception as e:
-                    self.fail(f"""{filetype_name.upper()} decode error {e}: Original object:
-{orig_obj!r}
-Expected format:
-{representation.decode("utf-8")}
-Actual format:
-{formatted_str!s}""")
-            if test_equality:
-                self.assertEqual(tree, new_obj)
+        for iteration in trange(iterations):
+            random.seed(f'{RUN_SEED}:{filetype_name}:{iteration}')
+            try:
+                with run_with_time_limit(ITERATION_TIME_LIMIT_SECONDS):
+                    _round_trip(self, filetype, formatter, test_func, test_equality=test_equality)
+            except TimeoutError:
+                self.fail(
+                    f'Iteration {iteration} of {test_func.__name__} took longer than '
+                    f'{ITERATION_TIME_LIMIT_SECONDS} seconds. Rerun with '
+                    f'{SEED_ENVIRONMENT_VARIABLE}={RUN_SEED} in the environment to reproduce the document that '
+                    f'caused it.'
+                )
 
     return wrapper
 
@@ -197,6 +251,23 @@ class TestFormatting(TestCase):
         for name in graphtage.FILETYPES_BY_TYPENAME.keys():
             if not hasattr(self, f'test_{name}_formatting'):
                 self.fail(f"Filetype {name} is missing a `test_{name}_formatting` test function")
+
+    def test_random_documents_are_reproducible(self):
+        """Every iteration draws from a seed derived from :data:`RUN_SEED`, so recording it replays the run."""
+        random.seed(f'{RUN_SEED}:json:0')
+        first = TestFormatting.make_random_obj(force_string_keys=True)
+        random.seed(f'{RUN_SEED}:json:0')
+        self.assertEqual(first, TestFormatting.make_random_obj(force_string_keys=True))
+
+    def test_slow_iteration_fails_with_the_seed(self):
+        """A pathological document must fail with the seed that produced it, not stall the job."""
+        @filetype_test(iterations=1)
+        def test_json_formatting(_):
+            time.sleep(2)
+
+        with patch(f'{__name__}.ITERATION_TIME_LIMIT_SECONDS', 1), self.assertRaises(AssertionError) as failure:
+            test_json_formatting(self)
+        self.assertIn(f'{SEED_ENVIRONMENT_VARIABLE}={RUN_SEED}', str(failure.exception))
 
     @staticmethod
     def render(formatter: graphtage.GraphtageFormatter, node: graphtage.TreeNode) -> str:

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -263,7 +263,11 @@ class TestFormatting(TestCase):
         """A pathological document must fail with the seed that produced it, not stall the job."""
         @filetype_test(iterations=1)
         def test_json_formatting(_):
-            time.sleep(2)
+            # Busy-wait rather than sleep, so that this exercises the same interruption path as a pathological
+            # document. The deadline only keeps the test from hanging if the budget fails to interrupt it.
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                pass
 
         with patch(f'{__name__}.ITERATION_TIME_LIMIT_SECONDS', 1), self.assertRaises(AssertionError) as failure:
             test_json_formatting(self)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -3,9 +3,29 @@ from collections import Counter
 from unittest import TestCase
 
 from graphtage.json import build_tree
+from graphtage.sequences import SequenceNode
 from graphtage.utils import HashableCounter, largest, smallest, SparseMatrix
 
 from .timing import run_with_time_limit
+
+
+def _count_comparisons(first, second) -> int:
+    """Returns the number of :meth:`SequenceNode.__eq__` calls that comparing `first` to `second` makes."""
+    original = SequenceNode.__eq__
+    calls = 0
+
+    def counted(self, other):
+        nonlocal calls
+        calls += 1
+        return original(self, other)
+
+    SequenceNode.__eq__ = counted
+    try:
+        if first != second:
+            raise AssertionError('the two trees must be equal for the comparison to traverse them')
+    finally:
+        SequenceNode.__eq__ = original
+    return calls
 
 
 class TestSparseMatrix(TestCase):
@@ -71,12 +91,19 @@ class TestHashableCounter(TestCase):
         """Comparing deeply nested dictionaries must not be exponential in the nesting depth.
 
         :meth:`collections.Counter.__eq__` looks up every element in both counters, so each level of nesting
-        compares its children twice. Before :class:`graphtage.utils.HashableCounter` overrode it, comparing this
-        61-node document against itself doubled in cost for every level and took over half an hour.
+        compares its children twice and the whole comparison makes ``2 ** (depth + 1) - 1`` calls. Before
+        :class:`graphtage.utils.HashableCounter` overrode it, comparing this document against itself took over
+        half an hour.
+
+        The assertion counts comparisons rather than measuring elapsed time, so it does not depend on how fast
+        the machine is. The time limit is a backstop that stops a regression from hanging the suite: at this
+        depth the exponential version would make more than two billion calls.
 
         """
-        obj = 'leaf'
-        for i in range(30):
-            obj = {f'key{i}': obj, f'other{i}': i}
+        depth = 30
+        obj = {'leaf': 'x'}
+        for i in range(depth):
+            obj = {f'k{i}': obj}
         with run_with_time_limit(seconds=5):
-            self.assertEqual(build_tree(obj), build_tree(obj))
+            calls = _count_comparisons(build_tree(obj), build_tree(obj))
+        self.assertLess(calls, 10 * depth, f'{calls} comparisons at depth {depth} is not linear')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,11 @@
 import sys
+from collections import Counter
 from unittest import TestCase
 
-from graphtage.utils import largest, smallest, SparseMatrix
+from graphtage.json import build_tree
+from graphtage.utils import HashableCounter, largest, smallest, SparseMatrix
+
+from .timing import run_with_time_limit
 
 
 class TestSparseMatrix(TestCase):
@@ -49,3 +53,30 @@ class TestSparseMatrix(TestCase):
             self.assertLess(1000 - 11, i)
         for i in largest(*list(range(1000)), n=10):
             self.assertLess(1000 - 11, i)
+
+
+class TestHashableCounter(TestCase):
+    def test_equality_matches_counter(self):
+        self.assertEqual(HashableCounter('aab'), Counter('aab'))
+        self.assertNotEqual(HashableCounter('aab'), Counter('ab'))
+        self.assertNotEqual(HashableCounter('aab'), Counter('aabc'))
+        self.assertNotEqual(HashableCounter('aab'), Counter('abb'))
+        self.assertNotEqual(HashableCounter('aab'), 'aab')
+        self.assertEqual(HashableCounter(), Counter())
+        # collections.Counter treats a missing count and a zero count as the same:
+        self.assertEqual(HashableCounter({'a': 1, 'b': 0}), Counter({'a': 1}))
+        self.assertEqual(HashableCounter({'a': 1}), Counter({'a': 1, 'b': 0}))
+
+    def test_nested_equality_is_not_exponential(self):
+        """Comparing deeply nested dictionaries must not be exponential in the nesting depth.
+
+        :meth:`collections.Counter.__eq__` looks up every element in both counters, so each level of nesting
+        compares its children twice. Before :class:`graphtage.utils.HashableCounter` overrode it, comparing this
+        61-node document against itself doubled in cost for every level and took over half an hour.
+
+        """
+        obj = 'leaf'
+        for i in range(30):
+            obj = {f'key{i}': obj, f'other{i}': i}
+        with run_with_time_limit(seconds=5):
+            self.assertEqual(build_tree(obj), build_tree(obj))

--- a/test/timing.py
+++ b/test/timing.py
@@ -5,14 +5,34 @@ from contextlib import contextmanager
 
 @contextmanager
 def run_with_time_limit(seconds: int):
-    timer = threading.Timer(seconds, _thread.interrupt_main)
-    timer.start()
+    """Runs the wrapped block, raising :class:`TimeoutError` if it takes longer than `seconds`.
 
+    The timer interrupts the main thread, so the block must be interruptible Python code, and this context manager
+    must be entered from the main thread.
+
+    Any other exception the block raises propagates unchanged.
+
+    Args:
+        seconds: The wall-clock budget for the block.
+
+    Raises:
+        TimeoutError: If the block is still running when the budget expires.
+
+    """
+    timed_out = False
+
+    def interrupt():
+        nonlocal timed_out
+        timed_out = True
+        _thread.interrupt_main()
+
+    timer = threading.Timer(seconds, interrupt)
+    timer.start()
     try:
         yield
-        return
-    except:
-        pass
+    except KeyboardInterrupt:
+        if not timed_out:
+            raise
+        raise TimeoutError(f"timeout after {seconds} seconds")
     finally:
         timer.cancel()
-    raise TimeoutError(f"timeout after {seconds} seconds")


### PR DESCRIPTION
Closes #134

## What is actually slow

The hours-long CI jobs are not caused by tree building, formatting, or the matching machinery. They are caused
by `assertEqual(tree, new_obj)` at the end of each `filetype_test` iteration.

`DictNode` is a `MultiSetNode`, so its children live in a `graphtage.utils.HashableCounter`. CPython 3.10 added
`Counter.__eq__`:

```python
return all(self[e] == other[e] for c in (self, other) for e in c)
```

It iterates over the elements of *both* counters, so every element is looked up once in each direction. Looking
an element up hashes it and then compares it, and comparing a `KeyValuePairNode` recurses into its value. Each
level of nesting therefore compares its child subtrees twice, and the cost of comparing two trees doubles per
level of nested dictionaries.

Measured on Python 3.12, comparing a nested dictionary against an identical copy:

| Nesting depth | Nodes | Seconds | Ratio to previous depth |
| ---: | ---: | ---: | ---: |
| 16 | 33 | 0.12 | 2.00 |
| 18 | 37 | 0.47 | 2.01 |
| 20 | 41 | 1.87 | 1.99 |
| 22 | 45 | 7.62 | 2.02 |
| 23 | 47 | 15.20 | 1.99 |

The ratio is 2.00 at every step. It is exponential in nesting depth and almost independent of document size: 47
nodes, 15 seconds. Depth 30 takes over half an hour, and depth 33 takes several hours.

**Python 3.8 and 3.9 are not affected.** `Counter` had no `__eq__` of its own before 3.10 and inherited the
linear `dict.__eq__` from C. That matches the evidence in the issue exactly: every outlier landed on 3.10 or
3.12, and none on 3.8 or 3.9. So the effect is not tied to one interpreter version, but it does have a floor at
Python 3.10.

## Why the tail is unbounded

`make_random_obj` builds documents with a branching process whose mean offspring count is about 0.80, so the
depth distribution has a geometric tail. Measured over 20,000 documents drawn with the TOML generator's
settings, `P(depth >= d)` decays by a factor of about 0.78 per level while the comparison cost grows by a
factor of 2 per level. Because 2 x 0.78 > 1, the expected cost per iteration diverges: the distribution has no
finite mean, which is why the job duration is unbounded rather than merely variable.

`test_toml_formatting` is the worst affected because it passes `allow_lists=False`, so every container is a
dictionary and every level of nesting doubles the cost. `test_yaml_formatting` alternates dictionaries and
lists, so it only doubles every other level, and `ListNode` children are tuples that compare linearly.
`test_plist_formatting` and `test_xml_formatting` pass `test_equality=False` and never compare at all.

## Reproducing case

Seeding `random` with `573` and running one iteration of `test_toml_formatting` produces a 323-node, 27-deep
TOML document, 60,212 bytes:

```
gen=0.00s  build=0.01s  format=0.30s  reparse=0.01s  equality=237.42s
```

Over 1,000 seeds of `test_toml_formatting`, six exceeded one second and the worst took 237 seconds. The
formatting tests run 200 TOML iterations per CI job, drawn from that same distribution.

## The fix

`HashableCounter` now overrides `__eq__` to probe only one side. It keeps `collections.Counter` semantics,
including treating a missing count and a zero count as the same, and is linear in the total number of elements.

The effect is asymptotic, not a constant factor. Counting `SequenceNode.__eq__` calls while comparing two equal
trees nested `d` deep, master makes `2^(d+1)-1` calls and this branch makes `d+1`:

| depth | master calls | master | branch calls | branch |
| ---: | ---: | ---: | ---: | ---: |
| 8 | 511 | 0.0012s | 9 | 0.0000s |
| 12 | 8,191 | 0.0181s | 13 | 0.0000s |
| 16 | 131,071 | 0.2873s | 17 | 0.0000s |
| 20 | 2,097,151 | 4.6331s | 21 | 0.0001s |
| 22 | 8,388,607 | 18.6900s | 23 | 0.0001s |

This is a library fix, not a test fix. The same comparison runs inside `MultiSetNode.edits`, so real diffs hit
it too. Diffing `{"same": <shared subtree nested d deep>, "differs": ...}` against a copy whose `differs` value
changed:

| depth | master | branch |
| ---: | ---: | ---: |
| 16 | 1.7670s | 0.0011s |
| 18 | 7.2299s | 0.0011s |
| 20 | 28.0703s | 0.0012s |

The rendered diff output is byte-for-byte identical before and after.

### Scope: where this changes nothing

The fix helps when nested multiset containers are **equal**, because that is when `Counter.__eq__` traverses
the whole structure. When a difference changes hashes up the spine, `all()` short-circuits and master was
already fast:

| scenario, depth 20 | master | branch |
| --- | ---: | ---: |
| Two equal trees | 2.11s | 0.0000s |
| Differing at the deepest leaf | 0.0000s | 0.0000s |
| Differing at a root key | 0.0000s | 0.0000s |

Equal subtrees are the case that matters in practice: they are most of what a diff of two similar documents is
made of, and they are the whole of the round-trip test, which compares a document against itself.

`HashableCounter.__hash__` is not involved. Instrumented, it is called zero times during a tree comparison on
both master and this branch, because `KeyValuePairNode` caches its hash at construction.

### Reproducing these numbers

`sys.path[0]` is the script's directory (or the working directory for `python -c`) and precedes an editable
install, so a reproducer run from a master checkout imports master's `graphtage` even under this branch's venv.
Any benchmark for this change should print the loaded `graphtage/utils.py` and whether the override is present
in the same process that does the timing:

```python
import sys, collections
from graphtage.utils import HashableCounter
print(sys.modules["graphtage.utils"].__file__)
print("FIX PRESENT:", "__eq__" in HashableCounter.__dict__)
```

On this branch that prints the worktree path and `True`; on master it prints `False`.

## Keeping pathological cases visible

Fixing the comparison removes the cause we know about. It does not stop the next one from being invisible, so
the test harness changes too:

- Every iteration's document is derived from a run seed, which `GRAPHTAGE_TEST_SEED` overrides. The seed is
  printed at the start of each filetype test, and each iteration is seeded independently from
  `f"{RUN_SEED}:{filetype}:{iteration}"`, so replaying a run reproduces the exact document that iteration N
  drew without replaying the ones before it.
- Each iteration gets a 30 second budget through the existing `test.timing.run_with_time_limit` helper. A
  pathological document now fails with a message naming the seed rather than stalling the job.

`run_with_time_limit` had a bare `except` that swallowed everything the wrapped block raised and reported it as
a timeout, which would have turned genuine formatting failures into confusing `TimeoutError`s. It now converts
only the `KeyboardInterrupt` its own timer raises and lets everything else propagate.

## Trade-off on fuzzing coverage

**No iteration counts are reduced.** The tests still generate 1,000 random documents for JSON, CSV, YAML, and
plist, 250 for XML, and 200 for TOML, drawn from the same distributions as before. Recording the seed keeps the
exploration while making a bad draw reproducible, which is the property the fuzzing was missing. The seed is
random per run unless `GRAPHTAGE_TEST_SEED` is set, so consecutive CI runs still explore different documents.

The 30 second budget is the one place coverage could in principle be lost: a document that legitimately needs
more than 30 seconds would now fail. The worst iteration across 1,000 seeds of the slowest filetype now takes
0.33 seconds, of which 0.32 is formatting a 64 KB document, so the budget is roughly a hundredfold margin over
the observed worst case. Anything that reaches it is a performance bug worth seeing.

## Evidence that the harness works

Running `test_toml_formatting` under 25 fixed seeds, with the library fix reverted and the 30 second budget in
place:

| | Result |
| --- | --- |
| Before the fix | 6 of 25 seeds failed at the budget; passing runs took 1s to 20s |
| After the fix | 25 of 25 seeds passed in 1s to 2s |

Without the harness change those six seeds would have been silent multi-minute or multi-hour successes.

## Tests

- `TestHashableCounter.test_equality_matches_counter` pins the `collections.Counter` semantics the override has
  to preserve, including the zero-count cases.
- `TestHashableCounter.test_nested_equality_is_not_exponential` compares a 61-node document nested 30 deep
  under a 5 second limit. On master it times out; with the fix it finishes in well under a millisecond.
- `TestFormatting.test_random_documents_are_reproducible` checks that the seeding scheme replays a document.
- `TestFormatting.test_slow_iteration_fails_with_the_seed` checks that an iteration over the budget fails with
  a message naming the seed.

`test_formatter_coverage` is untouched and still passes.

## Verification

- 123 tests pass on Python 3.12 in about 31 seconds, and on Python 3.8 in about 50 seconds. Master is 119 tests
  in about 28 seconds on 3.12, so the harness adds roughly a second of timer overhead plus the four new tests.
- Ran the suite four times to check for flakiness; all four passed.
- `ruff check graphtage test` reports one fewer finding than master (the bare `except` in `test/timing.py` is
  gone) and adds none.
- `flake8 graphtage test --select=E9,F63,F7,F82` passes.

Both CI runs on this branch finished every `build` job within a minute of each other, with no outlier:

| Python | Run 34164728657 | Run 34164906016 |
| --- | ---: | ---: |
| 3.8 | 2m 23s | 1m 31s |
| 3.9 | 2m 25s | 2m 22s |
| 3.10 | 2m 21s | 2m 00s |
| 3.11 | 1m 56s | 1m 25s |
| 3.12 | 2m 07s | 2m 01s |
| 3.13 | 2m 05s | 2m 02s |

Two runs prove nothing on their own, given that most runs on master were already fast. The argument that the
tail is gone rests on the seed sweep above, not on these two runs.

## Note for reviewers

Commits are unsigned; signing was unavailable in the environment that produced them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
