### PR TITLE
Add INI filetype support

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,8 +6,8 @@ title: Graphtage
 message: >-
   Graphtage is a command-line utility and underlying library
   for semantically comparing and merging tree-like
-  structures, such as JSON, XML, HTML, YAML, plist, and CSS
-  files.
+  structures, such as JSON, JSON5, XML, HTML, YAML, TOML, INI,
+  CSV, plist, and Python pickle files.
 type: software
 authors:
   - given-names: Evan
@@ -20,8 +20,8 @@ url: 'https://trailofbits.github.io/graphtage/'
 abstract: >-
   Graphtage is a command-line utility and underlying library
   for semantically comparing and merging tree-like
-  structures, such as JSON, XML, HTML, YAML, plist, and CSS
-  files. Its name is a portmanteau of “graph” and
+  structures, such as JSON, JSON5, XML, HTML, YAML, TOML, INI,
+  CSV, plist, and Python pickle files. Its name is a portmanteau of “graph” and
   “graftage”—the latter being the horticultural practice of
   joining two trees together such that they grow as one.
 keywords:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Graphtage is a semantic diff/merge utility for tree-like structured data formats (JSON, XML, HTML, YAML, plist, CSS, CSV). It works as both a command-line tool and Python library.
+Graphtage is a semantic diff/merge utility for tree-like structured data formats (JSON, JSON5, XML, HTML, YAML, TOML, INI, CSV, plist, Python pickle). It works as both a command-line tool and Python library.
 
 Key capabilities:
 - Semantic understanding of tree structures (recognizes key vs value changes)
@@ -39,7 +39,7 @@ Key capabilities:
 
 ### File Format Modules
 Each format implements its own TreeNode subclasses and parser:
-- json.py, yaml.py, xml.py, csv.py, plist.py, pickle.py
+- json.py, yaml.py, xml.py, csv.py, toml.py, ini.py, plist.py, pickle.py
 
 ## Development Setup
 
@@ -78,11 +78,35 @@ cd docs && make html
 ## Code Patterns
 
 ### Adding a New File Format
-1. Create `graphtage/newformat.py`
-2. Define TreeNode subclasses for format-specific structures
-3. Implement a `build_tree(content: str) -> TreeNode` function
-4. Register the filetype in `graphtage/__init__.py`
-5. Add tests in `test/test_newformat.py`
+1. Create `graphtage/newformat.py`.
+2. Define a `Filetype` subclass with a zero-argument `__init__`. `FiletypeWatcher` instantiates it at
+   class-definition time, so it must implement `build_tree`, `build_tree_handling_errors`, and
+   `get_default_formatter`. Registration into `FILETYPES_BY_TYPENAME` and `FILETYPES_BY_MIME` is automatic, and
+   that is what generates the `--from-*`, `--to-*`, and `--format` CLI flags.
+3. Implement `build_tree(path: str, options: Optional[BuildOptions] = None) -> TreeNode`. Reusing
+   `graphtage.json.build_tree` on a plain Python object gets you the whole `TreeNode` contract for free.
+4. Add the module to the `from . import ...` line in `graphtage/__init__.py`. Nothing registers without it, and
+   `docs/build_api.py` discovers API pages from this import.
+5. Add the extension to `register_mimetypes()` in `graphtage/__main__.py`. `mimetypes` does not know most of these,
+   and format detection is extension-based, so without this every diff fails with "Could not determine the filetype".
+6. Add a `test_<typename>_formatting` method to `test/test_formatting.py`, or `test_formatter_coverage` fails. Note
+   that `@filetype_test` only round-trips *unedited* trees, so it cannot catch a formatter that mishandles edits —
+   add a separate diff-level test for insertions and removals.
+7. Give the formatter `print_UnorderedListNode = print_ListNode`, or `test_unordered_list_renders_like_a_list`
+   fails. A formatter that cannot resolve a node type bounces to `self.parent.print(...)` and recurses forever.
+8. Mark helper formatters `is_partial = True` so they stay out of the global `FORMATTERS` list, where they could
+   change how unrelated formats resolve node types.
+9. Update the format lists in `README.md`, `docs/index.rst`, `CITATION.cff`, `pyproject.toml`, the `--help`
+   description in `graphtage/__main__.py`, and this file.
+10. Add a dependency to `pyproject.toml` only if the parser is third-party, and regenerate `uv.lock`.
+
+Route printing through `SequenceFormatter.print_SequenceNode`, which is where insert and remove edits are applied;
+iterating a node's children directly silently drops them. Only one formatter may define `print_<NodeType>` for a
+given type, so distinguish nesting levels in the key/value formatter rather than by node type (see
+`graphtage/yaml.py` and `graphtage/ini.py`).
+
+Python 3.8 compatibility is required. Do not use PEP 585 builtin generics (`list[...]`, `dict[...]`) in
+runtime-evaluated positions such as annotated class attributes; use `typing.List` or drop the annotation.
 
 ### Working with Edits
 - Edit costs are computed lazily via `bounds()` method

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Slack Status](https://slack.empirehacking.nyc/badge.svg)](https://slack.empirehacking.nyc)
 
 Graphtage is a command-line utility and [underlying library](https://trailofbits.github.io/graphtage/latest/library.html)
-for semantically comparing and merging tree-like structures, such as JSON, XML, HTML, YAML, TOML, plist, and CSS files. Its name is a
-portmanteau of “graph” and “graftage”—the latter being the horticultural practice of joining two trees together such
-that they grow as one.
+for semantically comparing and merging tree-like structures, such as JSON, JSON5, XML, HTML, YAML, TOML, INI, CSV,
+plist, and Python pickle files. Its name is a portmanteau of “graph” and “graftage”—the latter being the horticultural
+practice of joining two trees together such that they grow as one.
 
 ```console
 $ echo Original: && cat original.json && echo Modified: && cat modified.json

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,8 @@ Graphtage Documentation
 =======================
 
 Graphtage is *both* a commandline utility *and* a general purpose library for semantically comparing and merging
-tree-like structures, such as JSON, XML, HTML, YAML, and CSV files. Its name is a portmanteau of “graph” and
+tree-like structures, such as JSON, JSON5, XML, HTML, YAML, TOML, INI, CSV, plist, and Python pickle files. Its name is
+a portmanteau of “graph” and
 “graftage”—the latter being the practice of joining two trees together such that they grow as one.
 
 There are several reasons why you might be here…

--- a/graphtage/__init__.py
+++ b/graphtage/__init__.py
@@ -9,7 +9,7 @@ from . import (
     ast, bounds, builder, constraints, dataclasses, edits, expressions, fibonacci, formatter, levenshtein, matching,
     object_set, pickle, printer, pydiff, search, sequences, tree, utils
 )
-from . import csv, json, plist, toml, xml, yaml
+from . import csv, ini, json, plist, toml, xml, yaml
 
 import inspect
 

--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -227,6 +227,8 @@ def main(argv=None) -> int:
         mimetypes.add_type('application/json5', '.json5')
     if '.toml' not in mimetypes.types_map:
         mimetypes.add_type('application/toml', '.toml')
+    if '.ini' not in mimetypes.types_map:
+        mimetypes.add_type('text/ini', '.ini')
     if '.plist' not in mimetypes.types_map:
         mimetypes.add_type('application/x-plist', '.plist')
     if '.pkl' not in mimetypes.types_map and '.pickle' not in mimetypes.types_map:

--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -76,7 +76,8 @@ def register_mimetypes():
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
-        description='A diff utility for tree-like files such as JSON, XML, HTML, YAML, and CSV.'
+        description='A diff utility for tree-like files such as JSON, JSON5, XML, HTML, YAML, TOML, INI, CSV, plist, '
+                    'and Python pickle.'
     )
     parser.add_argument('FROM_PATH', type=str, nargs='?', default='-',
                         help='the source file to diff; pass \'-\' to read from STDIN')

--- a/graphtage/ini.py
+++ b/graphtage/ini.py
@@ -1,0 +1,92 @@
+"""A :class:`graphtage.Filetype` for parsing, diffing, and rendering INI files."""
+
+import configparser
+import os
+from typing import ClassVar, Optional, Type, Union
+
+from . import json
+from .graphtage import BuildOptions, Filetype, KeyValuePairNode, MappingNode, StringFormatter, StringNode
+from .printer import Printer
+from .tree import GraphtageFormatter, TreeNode
+
+
+def _parser() -> configparser.ConfigParser:
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.optionxform = str
+    return parser
+
+
+def build_tree(path: str, options: Optional[BuildOptions]) -> TreeNode:
+    parser = _parser()
+    with open(path) as f:
+        parser.read_file(f)
+
+    data = {}
+    if parser.defaults():
+        data[parser.default_section] = dict(parser.defaults())
+    for section in parser.sections():
+        data[section] = dict(parser[section])
+    return json.build_tree(data, options)
+
+
+class INIStringFormatter(StringFormatter):
+    """A string formatter for INI keys and values."""
+    is_partial = True
+
+    def escape(self, c: str) -> str:
+        return c.replace("\n", "\\n")
+
+
+class INIFormatter(GraphtageFormatter):
+    """A formatter for INI files."""
+    sub_format_types: ClassVar[list[Type[GraphtageFormatter]]] = [INIStringFormatter]
+
+    def print_KeyValuePairNode(self, printer: Printer, node: KeyValuePairNode):
+        if isinstance(node.key, StringNode):
+            node.key.quoted = False
+        self.print(printer, node.key)
+        printer.write(" = ")
+        if isinstance(node.value, StringNode):
+            node.value.quoted = False
+        self.print(printer, node.value)
+        printer.newline()
+
+    def print_MappingNode(self, printer: Printer, node: MappingNode):
+        for section in node:
+            if not isinstance(section.value, MappingNode):
+                continue
+            printer.write("[")
+            if isinstance(section.key, StringNode):
+                section.key.quoted = False
+            self.print(printer, section.key)
+            printer.write("]")
+            printer.newline()
+            for item in section.value:
+                self.print(printer, item)
+            printer.newline()
+
+
+class INI(Filetype):
+    """The INI filetype."""
+
+    def __init__(self):
+        """Initializes the INI filetype."""
+        super().__init__(
+            "ini",
+            "text/ini",
+            "application/ini",
+            "text/x-ini",
+        )
+
+    def build_tree(self, path: str, options: Optional[BuildOptions] = None) -> TreeNode:
+        """Equivalent to :func:`build_tree`"""
+        return build_tree(path, options=options)
+
+    def build_tree_handling_errors(self, path: str, options: Optional[BuildOptions] = None) -> Union[str, TreeNode]:
+        try:
+            return self.build_tree(path=path, options=options)
+        except (configparser.Error, OSError) as e:
+            return f"Error parsing {os.path.basename(path)}: {e}"
+
+    def get_default_formatter(self) -> INIFormatter:
+        return INIFormatter.DEFAULT_INSTANCE

--- a/graphtage/ini.py
+++ b/graphtage/ini.py
@@ -1,32 +1,56 @@
-"""A :class:`graphtage.Filetype` for parsing, diffing, and rendering INI files."""
+"""A :class:`graphtage.Filetype` for parsing, diffing, and rendering INI files.
+
+The parser is implemented atop :mod:`configparser`. Option names are compared case-sensitively, which differs from
+:mod:`configparser`'s default of lowercasing them, so that a diff reflects the file as it was written. Interpolation is
+disabled for the same reason, and ``[DEFAULT]`` is treated as an ordinary section rather than supplying values to every
+other section. Comments are not represented in the tree, so they are absent from the output.
+
+When another format is rendered as INI, a top-level value that is not itself a mapping has no section to live under.
+It is written without a section header so that the diff is still visible, which means the output is not necessarily a
+file that :mod:`configparser` can read back.
+
+"""
 
 import configparser
 import os
-from typing import ClassVar, Optional, Type, Union
+from typing import Optional, Union
 
 from . import json
 from .graphtage import BuildOptions, Filetype, KeyValuePairNode, MappingNode, StringFormatter, StringNode
 from .printer import Printer
+from .sequences import SequenceFormatter
 from .tree import GraphtageFormatter, TreeNode
+
+DEFAULT_SECTION_SENTINEL = "\x00graphtage-no-default-section"
+"""A ``default_section`` name that cannot occur in a real file.
+
+:class:`configparser.ConfigParser` copies the options of its ``default_section`` into every other section. Pointing it
+at a name no file can contain keeps ``[DEFAULT]`` an ordinary section, so the tree matches the file as written.
+
+"""
 
 
 def _parser() -> configparser.ConfigParser:
-    parser = configparser.ConfigParser(interpolation=None)
+    parser = configparser.ConfigParser(interpolation=None, default_section=DEFAULT_SECTION_SENTINEL)
     parser.optionxform = str
     return parser
 
 
-def build_tree(path: str, options: Optional[BuildOptions]) -> TreeNode:
+def build_tree(path: str, options: Optional[BuildOptions] = None) -> TreeNode:
     parser = _parser()
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         parser.read_file(f)
-
-    data = {}
-    if parser.defaults():
-        data[parser.default_section] = dict(parser.defaults())
-    for section in parser.sections():
-        data[section] = dict(parser[section])
+    data = {section: dict(parser[section]) for section in parser.sections()}
     return json.build_tree(data, options)
+
+
+def _unquote(node: Optional[TreeNode]):
+    """Clears a string node's quoting, since INI has no string delimiters."""
+    if isinstance(node, StringNode):
+        node.quoted = False
+    elif isinstance(node, KeyValuePairNode):
+        _unquote(node.key)
+        _unquote(node.value)
 
 
 class INIStringFormatter(StringFormatter):
@@ -34,36 +58,96 @@ class INIStringFormatter(StringFormatter):
     is_partial = True
 
     def escape(self, c: str) -> str:
-        return c.replace("\n", "\\n")
+        # INI represents a multi-line value as indented continuation lines:
+        return c.replace("\n", "\n\t")
+
+
+class INIOptionFormatter(GraphtageFormatter):
+    """A formatter for a single INI key/value pair, or for a section header and its body."""
+    is_partial = True
+
+    def print_KeyValuePairNode(self, printer: Printer, node: KeyValuePairNode):
+        if isinstance(node.value, MappingNode):
+            printer.write("[")
+            self.print(printer, node.key)
+            printer.write("]")
+            printer.newline()
+            self.parent.print(printer, node.value)
+            printer.newline()
+        else:
+            self.print(printer, node.key)
+            printer.write(" = ")
+            self.print(printer, node.value)
+            printer.newline()
+
+
+class INIListFormatter(SequenceFormatter):
+    """A formatter for sequences.
+
+    INI has no syntax for a list, so one is written as a comma-separated value. This only arises when rendering
+    another format as INI; reading the result back yields a single string rather than a list.
+
+    """
+    is_partial = True
+
+    def __init__(self):
+        super().__init__("", "", ",")
+
+    def print_ListNode(self, *args, **kwargs):
+        super().print_SequenceNode(*args, **kwargs)
+
+    print_UnorderedListNode = print_ListNode
+
+    def print_SequenceNode(self, *args, **kwargs):
+        self.parent.print(*args, **kwargs)
+
+    def item_newline(self, printer: Printer, is_first: bool = False, is_last: bool = False):
+        pass
+
+    def items_indent(self, printer: Printer):
+        return printer
+
+
+class INIMappingFormatter(SequenceFormatter):
+    """A formatter for an INI document and for each of its section bodies."""
+    is_partial = True
+    sub_format_types = [INIOptionFormatter]
+
+    def __init__(self):
+        super().__init__("", "", "")
+
+    def print_MappingNode(self, *args, **kwargs):
+        super().print_SequenceNode(*args, **kwargs)
+
+    print_MultiSetNode = print_MappingNode
+
+    def print_SequenceNode(self, *args, **kwargs):
+        self.parent.print(*args, **kwargs)
+
+    def item_newline(self, printer: Printer, is_first: bool = False, is_last: bool = False):
+        # INI's line structure is written by INIOptionFormatter, which knows whether it is emitting a section
+        # header or an option; a delimiter here would double the newlines.
+        pass
+
+    def items_indent(self, printer: Printer):
+        return printer
 
 
 class INIFormatter(GraphtageFormatter):
     """A formatter for INI files."""
-    sub_format_types: ClassVar[list[Type[GraphtageFormatter]]] = [INIStringFormatter]
+    sub_format_types = [INIMappingFormatter, INIListFormatter, INIStringFormatter]
 
-    def print_KeyValuePairNode(self, printer: Printer, node: KeyValuePairNode):
-        if isinstance(node.key, StringNode):
-            node.key.quoted = False
-        self.print(printer, node.key)
-        printer.write(" = ")
-        if isinstance(node.value, StringNode):
-            node.value.quoted = False
-        self.print(printer, node.value)
-        printer.newline()
-
-    def print_MappingNode(self, printer: Printer, node: MappingNode):
-        for section in node:
-            if not isinstance(section.value, MappingNode):
-                continue
-            printer.write("[")
-            if isinstance(section.key, StringNode):
-                section.key.quoted = False
-            self.print(printer, section.key)
-            printer.write("]")
-            printer.newline()
-            for item in section.value:
-                self.print(printer, item)
-            printer.newline()
+    def print(self, printer: Printer, *args, **kwargs):
+        if args and isinstance(args[0], TreeNode) and args[0].parent is None:
+            # INI has no string delimiters. Sweeping the whole tree covers both sides of every edit, and also
+            # covers trees built by another filetype when rendering it as INI.
+            for node in args[0].dfs():
+                _unquote(node)
+                _unquote(getattr(node, "matched_to", None))
+                for inserted in getattr(node, "inserted", ()):
+                    for descendant in inserted.dfs():
+                        _unquote(descendant)
+        super().print(printer, *args, **kwargs)
 
 
 class INI(Filetype):
@@ -85,7 +169,7 @@ class INI(Filetype):
     def build_tree_handling_errors(self, path: str, options: Optional[BuildOptions] = None) -> Union[str, TreeNode]:
         try:
             return self.build_tree(path=path, options=options)
-        except (configparser.Error, OSError) as e:
+        except (configparser.Error, OSError, ValueError) as e:
             return f"Error parsing {os.path.basename(path)}: {e}"
 
     def get_default_formatter(self) -> INIFormatter:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graphtage"
-description = "A utility to diff tree-like files such as JSON and XML."
+description = "A utility to diff tree-like files such as JSON, XML, YAML, TOML, INI, CSV, and plist."
 readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "LGPL-3.0-or-later"}

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -1,5 +1,4 @@
 import csv
-import configparser
 import json
 import os
 import plistlib
@@ -341,13 +340,13 @@ class TestFormatting(TestCase):
 
     @filetype_test(iterations=200)
     def test_ini_formatting(self):
-        config = configparser.ConfigParser(interpolation=None)
-        config.optionxform = str
+        # Build the writer from the reader's own configuration so the two cannot drift apart:
+        config = graphtage.ini._parser()
         excluded = frozenset('\t \\\'"\r:[]{}&\n()`|+%<>#*^$@!~_+-=.,;?/')
         orig_obj = {
             TestFormatting.make_random_str(exclude_bytes=excluded, allow_empty_strings=False): {
                 TestFormatting.make_random_str(exclude_bytes=excluded, allow_empty_strings=False):
-                    TestFormatting.make_random_str(exclude_bytes=frozenset('\n\r'), allow_empty_strings=True)
+                    TestFormatting.make_random_str(exclude_bytes=frozenset('\r'), allow_empty_strings=True)
                 for _ in range(random.randint(1, 5))
             }
             for _ in range(random.randint(1, 5))

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -1,4 +1,5 @@
 import csv
+import configparser
 import json
 import plistlib
 import random
@@ -232,6 +233,25 @@ class TestFormatting(TestCase):
             return orig_obj, toml.dumps(orig_obj)
         except (TypeError, ValueError, IndexError) as e:
             self.fail(f"""Invalid random TOML object {orig_obj!r}: {e}""")
+
+    @filetype_test(iterations=200)
+    def test_ini_formatting(self):
+        config = configparser.ConfigParser(interpolation=None)
+        config.optionxform = str
+        excluded = frozenset('\t \\\'"\r:[]{}&\n()`|+%<>#*^$@!~_+-=.,;?/')
+        orig_obj = {
+            TestFormatting.make_random_str(exclude_bytes=excluded, allow_empty_strings=False): {
+                TestFormatting.make_random_str(exclude_bytes=excluded, allow_empty_strings=False):
+                    TestFormatting.make_random_str(exclude_bytes=frozenset('\n\r'), allow_empty_strings=True)
+                for _ in range(random.randint(1, 5))
+            }
+            for _ in range(random.randint(1, 5))
+        }
+        for section, options in orig_obj.items():
+            config[section] = options
+        s = StringIO()
+        config.write(s)
+        return orig_obj, s.getvalue()
 
     @staticmethod
     def make_random_xml() -> xml.XMLElementObj:

--- a/test/test_ini.py
+++ b/test/test_ini.py
@@ -1,0 +1,83 @@
+from io import StringIO
+from unittest import TestCase
+
+import graphtage
+import graphtage.ini
+from graphtage.printer import Printer
+from graphtage.utils import Tempfile
+
+ONE_SECTION = b"""[alpha]
+x = 1
+"""
+
+TWO_SECTIONS = b"""[alpha]
+x = 1
+
+[beta]
+y = 2
+"""
+
+TWO_OPTIONS = b"""[alpha]
+x = 1
+z = 3
+"""
+
+WITH_DEFAULTS = b"""[DEFAULT]
+shared = 1
+
+[alpha]
+x = 2
+"""
+
+
+def build(content: bytes) -> graphtage.TreeNode:
+    with Tempfile(content) as path:
+        return graphtage.FILETYPES_BY_TYPENAME["ini"].build_tree(path)
+
+
+def render(node: graphtage.TreeNode) -> str:
+    stream = StringIO()
+    printer = Printer(out_stream=stream, ansi_color=False)
+    graphtage.FILETYPES_BY_TYPENAME["ini"].get_default_formatter().print(printer, node)
+    printer.flush(final=True)
+    return stream.getvalue()
+
+
+def render_diff(from_content: bytes, to_content: bytes) -> str:
+    return render(build(from_content).diff(build(to_content)))
+
+
+class TestINIDiff(TestCase):
+    """Covers the diff path, which ``@filetype_test`` cannot reach because it only round-trips unedited trees."""
+
+    def test_removed_section_is_marked(self):
+        """A removed section used to render byte-identically to no change at all."""
+        unchanged = render_diff(TWO_SECTIONS, TWO_SECTIONS)
+        removed = render_diff(TWO_SECTIONS, ONE_SECTION)
+        self.assertNotEqual(unchanged, removed)
+        self.assertIn("~~", removed)
+        self.assertIn("beta", removed)
+
+    def test_added_section_is_visible(self):
+        added = render_diff(ONE_SECTION, TWO_SECTIONS)
+        self.assertIn("++", added)
+        self.assertIn("beta", added)
+
+    def test_added_option_is_visible(self):
+        added = render_diff(ONE_SECTION, TWO_OPTIONS)
+        self.assertIn("++", added)
+        self.assertIn("z", added)
+
+    def test_unchanged_document_has_no_edit_markers(self):
+        unchanged = render_diff(TWO_SECTIONS, TWO_SECTIONS)
+        self.assertNotIn("~~", unchanged)
+        self.assertNotIn("++", unchanged)
+        self.assertEqual(0, build(TWO_SECTIONS).diff(build(TWO_SECTIONS)).edited_cost())
+
+    def test_default_section_is_not_copied_into_other_sections(self):
+        """``configparser`` serves DEFAULT options from every section; the tree must match the file as written."""
+        self.assertEqual({"DEFAULT": {"shared": "1"}, "alpha": {"x": "2"}}, build(WITH_DEFAULTS).to_obj())
+
+    def test_replaced_value_is_unquoted_on_both_sides(self):
+        """INI has no string delimiters, so neither side of a replacement may be quoted."""
+        self.assertNotIn('"', render_diff(ONE_SECTION, b"[alpha]\nx = 2\n"))


### PR DESCRIPTION
Adds INI support, building on @0xTaoZ's implementation from #120 with fixes for the defects that review found.

Closes #49.

## What #120 contributed

The approach is sound and unchanged: parse with `configparser` (no new dependency) and delegate to `graphtage.json.build_tree`, so the whole `TreeNode` contract — equality, hashing, `children()`, `edits()`, `to_obj()`, `calculate_total_size()` — comes for free rather than being reimplemented. @0xTaoZ's commit is preserved at the base of this branch.

## Defects fixed

**The formatter ignored edits.** `print_MappingNode` iterated a mapping's children directly, bypassing `SequenceFormatter.print_SequenceNode`, where insert and remove edits are applied. A removed section rendered byte-identically to no change at all, and added sections and keys were invisible. For a diff tool that is the worst available failure mode.

Both nesting levels now route through `SequenceFormatter`, following the `YAMLDictFormatter` / `YAMLKeyValuePairFormatter` pair. Only one formatter may claim `MappingNode`, so the section header is written by the key/value formatter rather than by a second mapping handler.

**`import graphtage` failed on Python 3.8.** `sub_format_types: ClassVar[list[Type[...]]]` is evaluated when the class body runs, and `list[...]` needs 3.9. Since `graphtage/__init__.py` imports this module, that took the entire package down on an interpreter the CI matrix still covers. Now a bare assignment, matching all five existing formatter modules.

**`[DEFAULT]` was copied into every section.** `configparser` serves default options from each section, so `shared` appeared both in `[DEFAULT]` and in every other section, and editing one default reported a change everywhere. Parsing with a `default_section` name no file can contain keeps `[DEFAULT]` an ordinary section, so the tree matches the file as written.

**Multi-line values were corrupted.** Escaping a newline to a literal `\n` changed the value on re-read. INI represents these as indented continuation lines, which round-trip.

**`--format ini` silently discarded data.** Every top-level value that was not a mapping was skipped, so rendering a flat document as INI produced nothing at all. Those values are now emitted without a section header, as `TOMLMapping.items()` does. The result is not always a file `configparser` can read back, which the module docstring says; emitting the diff beats dropping it.

**Malformed input raised a traceback.** `UnicodeDecodeError` is a `ValueError`, which the handler did not catch, so non-UTF-8 input escaped `build_tree_handling_errors`. It now reports `Error parsing <file>: ...`, matching `graphtage/toml.py`.

**Replacement values kept their quotes**, giving `x = 1 -> "2"`. Quoting is now cleared across the whole diff, following `matched_to` and `inserted`, because `dfs()` alone does not reach the far side of an edit.

## Two requirements that appeared after #120 was written

**#129** moved MIME registration into `register_mimetypes()`, so #120's inline `.ini` line no longer applied. Without it, every INI diff failed with `Could not determine the filetype`.

**#131** added `test_unordered_list_renders_like_a_list`, which iterates every registered filetype. INI had no list formatter, so a sequence bounced between formatters until it hit `RecursionError` — the same defect that PR's review found in TOML. `INIListFormatter` renders sequences comma-separated and carries the `print_UnorderedListNode` alias the other five formatters use.

## Tests

`@filetype_test` only round-trips *unedited* trees, so it structurally cannot catch the formatter defect above. `test/test_ini.py` covers the diff path directly: a removed section, an added section, an added option, `[DEFAULT]` handling, and quoting on a replacement. Five of its six tests fail against #120's module, each mapping to a specific defect; the sixth asserts unchanged input produces no markers and passes either way.

The existing round-trip test is fixed to build its writer from `graphtage.ini._parser()` rather than re-declaring the parser configuration, which matters because the reader and writer would otherwise disagree about `[DEFAULT]`. It also stops excluding newlines from generated values — that exclusion was masking the multi-line corruption bug, confirmed by reverting only `escape()` and watching the test fail.

## Format lists

The lists in the README, `docs/index.rst`, `CITATION.cff`, `pyproject.toml`, and the `--help` description were each stale in a different way, variously omitting TOML, plist, pickle, JSON5, and CSV. Two also claimed CSS support, which has never existed. All are corrected to the registered set.

`CLAUDE.md`'s "Adding a New File Format" recipe omitted the MIME registration step, the `print_UnorderedListNode` requirement, the `is_partial` rule, and the Python 3.8 constraint — every one of which was a defect here. It now covers them.

## Verification

- 136 tests pass on Python 3.8 and 3.13. `master` is at 123.
- `flake8 graphtage test --select=E9,F63,F7,F82` clean.
- `ruff check graphtage/ini.py` reports only `RUF012`, which `json.py`, `yaml.py`, `toml.py`, `csv.py`, and `plist.py` all trigger too.
- `cd docs && make html` succeeds; `graphtage.ini` is discovered automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
