### PR TITLE
Modernize the codebase for the Python 3.10 floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,17 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # uv.lock is committed and CI installs from it, so it needs updates of its own.
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: daily
+    groups:
+      python:
+        patterns:
+          - "*"

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -5,10 +5,13 @@ on:
     tags:
       - "v*"
 
+permissions: {}
+
 jobs:
   binaries:
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest ] # windows-latest,
 
@@ -19,23 +22,31 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          submodules: recursive
+          persist-credentials: false
+
+      # Pinned rather than 3.x so a given tag always builds against the same interpreter.
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.x'
+          python-version: "3.13"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools pyinstaller
+          pip install pyinstaller
           pip install .
+
       - name: Build the binary
         run: |
           make -C bindist
-          cd bindist && echo "DIST_FILE=`make dist-name | tr -d '\n'`" >> $GITHUB_ENV
+          echo "DIST_FILE=$(make -C bindist dist-name | tr -d '\n')" >> "$GITHUB_ENV"
+
+      - name: Check that the binary runs
+        run: bindist/dist/graphtage --version
+
       - name: Release binary artifacts
-        uses: softprops/action-gh-release@v3.0.3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           files: bindist/${{ env.DIST_FILE }}

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,5 +1,3 @@
-# IMPORTANT: Read and understand this template fully before applying it.
-
 name: Scan dependencies for vulnerabilities with pip-audit
 
 on:
@@ -7,8 +5,11 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  # New advisories are published against unchanged code, so this runs on a timer too.
   schedule:
     - cron: "0 12 * * *"
+
+permissions: {}
 
 jobs:
   pip-audit:
@@ -16,25 +17,23 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          # IMPORTANT: You may need a more specific version here.
-          python-version: "3.x"
+          python-version: "3.13"
 
       - name: Install project
         run: |
           python -m venv /tmp/pip-audit-env
           source /tmp/pip-audit-env/bin/activate
-
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip
           python -m pip install .
 
-
       - name: Run pip-audit
-        uses: pypa/gh-action-pip-audit@v1.1.0
+        uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266 # v1.1.0
         with:
           virtual-environment: /tmp/pip-audit-env
-

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -7,6 +7,12 @@ on:
     tags:
       - v*
 
+permissions: {}
+
+concurrency:
+  group: publish-docs
+  cancel-in-progress: false
+
 jobs:
   deploydocs:
     runs-on: ubuntu-latest
@@ -14,58 +20,52 @@ jobs:
       # NOTE: Needed to push to the repository.
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: graphtage
+          persist-credentials: false
+
       - name: Get the version
-        id: get_version
-        run: echo "::set-env name=VERSION::${GITHUB_REF#refs/*/}"
-        env:
-          # The use of ::set-env here is safe!
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v7
+        run: echo "VERSION=${GITHUB_REF#refs/*/}" >> "$GITHUB_ENV"
+
+      # No cache here: this job publishes, and a poisoned entry would reach gh-pages.
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: 3.12
-      - name: Install dependencies
-        run: |
-          cd graphtage
-          python -m pip install --upgrade pip
-          pip install setuptools
-          pip install .[dev]
+          enable-cache: false
+
       - name: Build documentation
-        run: |
-          cd graphtage/docs
-          make html
+        working-directory: graphtage
+        run: uv run --frozen --extra dev make -C docs html
+
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
           path: gh-pages
           fetch-depth: 0
+          persist-credentials: false
+
       - name: Commit documentation changes
+        working-directory: gh-pages
         run: |
-          cd gh-pages
           git pull
-          rm -rf ${VERSION}
-          mkdir ${VERSION}
-          cp -r ../graphtage/docs/_build/html/* ${VERSION}/
-          cd ${VERSION}
+          rm -rf "${VERSION}"
+          mkdir "${VERSION}"
+          cp -r ../graphtage/docs/_build/html/* "${VERSION}/"
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add .
+          git add "${VERSION}"
           if [ "$GITHUB_REF" == "refs/heads/master" ]; then
-            cd ..
-            # This is not tag, so it is the latest:
+            # This is not a tag, so it is the latest:
             rm -f latest
-            ln -s ${VERSION} latest
+            ln -s "${VERSION}" latest
             git add latest
           fi
+          # This fails when there is nothing to commit, which is not an error here.
           git commit -m "Update documentation for ${GITHUB_REF}" -a || true
-          # The above command will fail if no changes were present, so we ignore
-          # the return code.
+
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           branch: gh-pages
           directory: gh-pages

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,7 +31,7 @@ jobs:
 
       # The ruff version comes from the dev extra in pyproject.toml.
       - name: Lint with ruff
-        run: uv run --frozen --extra dev ruff check graphtage test
+        run: uv run --frozen --extra dev ruff check graphtage test docs bindist
 
       - name: Check that uv.lock matches pyproject.toml
         run: uv lock --check

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,5 +1,5 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# Installs dependencies, lints, builds the docs and runs the tests on every supported Python version.
+# For more information see: https://docs.github.com/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
 
@@ -9,38 +9,53 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
-  build:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+
+      # The ruff version comes from the dev extra in pyproject.toml.
+      - name: Lint with ruff
+        run: uv run --frozen --extra dev ruff check graphtage test
+
+      - name: Check that uv.lock matches pyproject.toml
+        run: uv lock --check
+
+  build:
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v7
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools
-        pip install .[dev]
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 graphtage test --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 graphtage test --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test building documentation
-      run: |
-        cd docs
-        make html
-    - name: Test with pytest
-      run: |
-        pip install pytest
-        pytest
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+
+      - name: Test building documentation
+        run: uv run --frozen --extra dev make -C docs html
+
+      - name: Test with pytest
+        run: uv run --frozen --extra dev pytest

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -21,14 +21,10 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
-
       - name: Build distributions
         run: |
-          python setup.py sdist bdist_wheel
+          python -m pip install --upgrade pip build
+          python -m build
 
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,13 +60,11 @@ pytest -q                   # Quiet output
 ```
 
 ### Linting
-```bash
-# Ruff is configured in pyproject.toml
-ruff check graphtage test
-ruff check --fix graphtage test
+Ruff is configured in `pyproject.toml` and gates CI, so the tree is expected to be clean.
 
-# CI currently uses flake8
-flake8 graphtage test --select=E9,F63,F7,F82
+```bash
+ruff check graphtage test docs bindist
+ruff check --fix graphtage test docs bindist
 ```
 
 ### Building Documentation
@@ -109,6 +107,12 @@ Python 3.10 is the minimum supported version. Check `requires-python` in `pyproj
 `.github/workflows/pythonpackage.yml` before using a feature from a newer release; a runtime-evaluated annotation
 that the floor does not support fails at import, which takes down the whole package.
 
+Never add `from __future__ import annotations` to this package. Two places read annotations at runtime, and PEP 563
+turns both into silent no-ops rather than errors: `DataClassNode.__init_subclass__` derives `_SLOTS` from
+`cls.__annotations__`, and `FormatterChecker` validates the `printer` parameter of every `print_*` method with
+`inspect.signature`. For the same reason, a `DataClassNode` slot annotation must name a `TreeNode` subclass
+directly; a subscripted generic is skipped, not turned into a slot.
+
 ### Working with Edits
 - Edit costs are computed lazily via `bounds()` method
 - Use `has_non_zero_cost()` to check if an edit represents a change
@@ -124,7 +128,8 @@ The printing system is extensible:
 
 - Line length: 120 characters (configured in ruff)
 - Python version: 3.10+ compatibility required; CI covers 3.10 through 3.14
-- Type hints: Use typing_extensions for Protocol support
+- Type hints: `typing.Protocol`; `typing_extensions` is not a dependency of the library
+- Annotations: PEP 585 and PEP 604 spellings (`list[str]`, `X | None`), not `typing.List` or `Optional`
 - Docstrings: Google style for public APIs
 - Tests: Mirror package structure in test/ directory
 

--- a/docs/build_api.py
+++ b/docs/build_api.py
@@ -3,13 +3,12 @@ import os
 import sys
 from pathlib import Path
 
-
 DOCS_PATH = os.path.dirname(os.path.realpath(__file__))
 ROOT_PATH = Path(DOCS_PATH).parents[0]
 
-sys.path = [ROOT_PATH] + sys.path
+sys.path = [ROOT_PATH, *sys.path]
 
-import graphtage
+import graphtage  # noqa: E402  (imported only after ROOT_PATH is on sys.path)
 
 MODULES = []
 
@@ -88,7 +87,7 @@ for name, obj in inspect.getmembers(graphtage, inspect.ismodule):
     if obj.__name__.startswith('graphtage') and name not in ('graphtage', 'tree', 'edits'):
         MODULES.append(obj)
 
-MODULES = [graphtage] + sorted(MODULES, key=lambda m: m.__name__)
+MODULES = [graphtage, *sorted(MODULES, key=lambda m: m.__name__)]
 
 for m in MODULES:
     process_module(m)

--- a/docs/builders.rst
+++ b/docs/builders.rst
@@ -117,5 +117,5 @@ You can add support for building Graphtage nodes from this custom class as follo
             yield node.attributes
 
         @Builder.builder(NonGraphtageClass)
-        def build_non_graphtage_class(node: NonGraphtageClass, children: List[TreeNode]) -> CustomNode:
+        def build_non_graphtage_class(node: NonGraphtageClass, children: list[TreeNode]) -> CustomNode:
             return CustomNode(*children)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ def get_version_string():
 # -- Project information -----------------------------------------------------
 
 project = 'Graphtage'
-copyright = '2020, Trail of Bits'
+copyright = '2020-2026, Trail of Bits'
 author = 'Evan Sultanik'
 
 # The full version, including alpha/beta/rc tags
@@ -73,10 +73,15 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 #html_theme = 'classic'
 html_theme = 'sphinx_rtd_theme'
 
+# Replaces the theme's deprecated canonical_url option.
+html_baseurl = 'https://trailofbits.github.io/graphtage/latest/'
+
 html_theme_options = {
-    'canonical_url': f'https://trailofbits.github.io/graphtage/latest/',
     'logo_only': False,
-    'display_version': False,   # This manually configured in our custom templates
+    # sphinx_rtd_theme 3.0 replaced display_version with these two. The version picker is
+    # built by hand in _templates/layout.html.
+    'version_selector': False,
+    'language_selector': False,
     'prev_next_buttons_location': 'bottom',
     'style_external_links': True,
     #'vcs_pageview_mode': '',
@@ -110,13 +115,12 @@ def skip(app, what, name, obj, would_skip, options):
 
 
 def docstring_callback(app, what, name, obj, options, lines: list):
-    if what == 'class' or what == 'function':
-        if lines and lines[0].strip():
-            lines.insert(1, '')
-            lines.insert(2, name)
-            lines.insert(3, '*' * len(name))
-            if len(lines) == 4:
-                lines.append('')
+    if what in ('class', 'function') and lines and lines[0].strip():
+        lines.insert(1, '')
+        lines.insert(2, name)
+        lines.insert(3, '*' * len(name))
+        if len(lines) == 4:
+            lines.append('')
 
 
 def setup(app):

--- a/docs/filetypes.rst
+++ b/docs/filetypes.rst
@@ -25,7 +25,7 @@ With the MIME type registered, here is a sketch of how one might define the Pick
 
 .. code-block:: python
 
-    from graphtage import BuildOptions, Filetype, Formatter, TreeNode
+    from graphtage import BuildOptions, Filetype, GraphtageFormatter, TreeNode
 
     class Pickle(Filetype):
         def __init__(self):
@@ -35,10 +35,10 @@ With the MIME type registered, here is a sketch of how one might define the Pick
                 "application/x-python-pickle"  # an optional secondary MIME type
             )
 
-        def build_tree(self, path: str, options: Optional[BuildOptions] = None) -> TreeNode:
+        def build_tree(self, path: str, options: BuildOptions | None = None) -> TreeNode:
             # return the root node of the tree built from the given pickle file
 
-        def build_tree_handling_errors(self, path: str, options: Optional[BuildOptions] = None) -> Union[str, TreeNode]:
+        def build_tree_handling_errors(self, path: str, options: BuildOptions | None = None) -> str | TreeNode:
             # the same as the build_tree() function,
             # but on error return a string containing the error message
             #

--- a/graphtage/__init__.py
+++ b/graphtage/__init__.py
@@ -18,7 +18,7 @@ import inspect
 # So the following code loops over those submodules and reassigns all of the classes to the top-level module.
 SUBMODULES_TO_SUBSUME = (graphtage, tree, edits)
 for module_to_subsume in SUBMODULES_TO_SUBSUME:
-    for name, obj in inspect.getmembers(module_to_subsume):
+    for _name, obj in inspect.getmembers(module_to_subsume):
         if hasattr(obj, '__module__') and obj.__module__ == module_to_subsume.__name__:
             obj.__module__ = 'graphtage'
     del module_to_subsume

--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -190,11 +190,11 @@ def main(argv=None) -> int:
     )
     log_section = parser.add_argument_group(title='logging')
     log_group = log_section.add_mutually_exclusive_group()
-    log_group.add_argument('--log-level', type=str, default='INFO', choices=list(
+    log_group.add_argument('--log-level', type=str, default='INFO', choices=[
         logging.getLevelName(x)
         for x in range(1, 101)
         if not logging.getLevelName(x).startswith('Level')
-    ), help='sets the log level for Graphtage (default=INFO)')
+    ], help='sets the log level for Graphtage (default=INFO)')
     log_group.add_argument('--debug', action='store_true', help='equivalent to `--log-level=DEBUG`')
     log_group.add_argument('--quiet', action='store_true', help='equivalent to `--log-level=CRITICAL --no-status`')
     parser.add_argument('--version', '-v', action='store_true', help='print Graphtage\'s version information to STDERR')
@@ -239,7 +239,7 @@ def main(argv=None) -> int:
         to_file = os.path.basename(args.TO_PATH)
 
         def printer_type(*pos_args, **kwargs):
-            return HTMLPrinter(title=f"Graphtage Diff of {from_file} and {to_file}", *pos_args, **kwargs)
+            return HTMLPrinter(*pos_args, title=f"Graphtage Diff of {from_file} and {to_file}", **kwargs)
     else:
         printer_type = Printer
 
@@ -264,7 +264,7 @@ def main(argv=None) -> int:
     if args.from_mime is not None:
         from_mime = args.from_mime
     else:
-        for typename in graphtage.FILETYPES_BY_TYPENAME.keys():
+        for typename in graphtage.FILETYPES_BY_TYPENAME:
             from_mime = getattr(args, f'from_{typename}')
             if from_mime is not None:
                 break
@@ -274,7 +274,7 @@ def main(argv=None) -> int:
     if args.to_mime is not None:
         to_mime = args.to_mime
     else:
-        for typename in graphtage.FILETYPES_BY_TYPENAME.keys():
+        for typename in graphtage.FILETYPES_BY_TYPENAME:
             to_mime = getattr(args, f'to_{typename}')
             if to_mime is not None:
                 break
@@ -314,64 +314,63 @@ def main(argv=None) -> int:
     try:
         with printer:
             options.printer = printer
-            with PathOrStdin(args.FROM_PATH) as from_path:
-                with PathOrStdin(args.TO_PATH) as to_path:
-                    try:
-                        from_format = graphtage.get_filetype(from_path, from_mime)
-                        to_format = graphtage.get_filetype(to_path, to_mime)
-                    except ValueError as e:
-                        sys.stderr.write(f"Error: {e!s}\n\n")
+            with PathOrStdin(args.FROM_PATH) as from_path, PathOrStdin(args.TO_PATH) as to_path:
+                try:
+                    from_format = graphtage.get_filetype(from_path, from_mime)
+                    to_format = graphtage.get_filetype(to_path, to_mime)
+                except ValueError as e:
+                    sys.stderr.write(f"Error: {e!s}\n\n")
+                    return EXIT_ERROR
+                with printer.tqdm(desc=f"Loading {from_path!s}", total=2, leave=False) as t:
+                    from_tree = from_format.build_tree_handling_errors(from_path, options)
+                    t.desc = f"Loading {to_path!s}"
+                    t.update(1)
+                    if isinstance(from_tree, str):
+                        sys.stderr.write(from_tree)
+                        sys.stderr.write('\n\n')
                         return EXIT_ERROR
-                    with printer.tqdm(desc=f"Loading {from_path!s}", total=2, leave=False) as t:
-                        from_tree = from_format.build_tree_handling_errors(from_path, options)
-                        t.desc = f"Loading {to_path!s}"
-                        t.update(1)
-                        if isinstance(from_tree, str):
-                            sys.stderr.write(from_tree)
-                            sys.stderr.write('\n\n')
-                            return EXIT_ERROR
-                        to_tree = to_format.build_tree_handling_errors(to_path, options)
-                        t.update(1)
-                        if isinstance(to_tree, str):
-                            sys.stderr.write(to_tree)
-                            sys.stderr.write('\n\n')
-                            return EXIT_ERROR
-                    if match_if is not None or match_unless is not None:
-                        for node in from_tree.dfs():
-                            if match_if is not None:
-                                MatchIf.apply(node, match_if)
-                            if match_unless is not None:
-                                MatchUnless.apply(node, match_unless)
-                    had_edits = False
-                    if args.only_edits:
-                        for edit in from_tree.get_all_edits(to_tree):
-                            printer.write(str(edit))
-                            printer.newline()
-                            had_edits = had_edits or edit.has_non_zero_cost()
-                    elif args.edit_digest:
-                        if args.format is not None:
-                            formatter = graphtage.FILETYPES_BY_TYPENAME[args.format].get_default_formatter()
-                        else:
-                            formatter = from_format.get_default_formatter()
-
-                        for ancestors, edit in from_tree.get_all_edit_contexts(to_tree):
-                            for i, node in enumerate(ancestors):
-                                if node.parent is not None:
-                                    node.parent.print_parent_context(printer, for_child=node)
-                                if i == len(ancestors) - 1:
-                                    with printer.color(Fore.BLUE):
-                                        printer.write(" -> ")
-                                    formatter.print(printer, edit)
-                            printer.newline()
-                            had_edits = had_edits or edit.has_non_zero_cost()
+                    to_tree = to_format.build_tree_handling_errors(to_path, options)
+                    t.update(1)
+                    if isinstance(to_tree, str):
+                        sys.stderr.write(to_tree)
+                        sys.stderr.write('\n\n')
+                        return EXIT_ERROR
+                if match_if is not None or match_unless is not None:
+                    for node in from_tree.dfs():
+                        if match_if is not None:
+                            MatchIf.apply(node, match_if)
+                        if match_unless is not None:
+                            MatchUnless.apply(node, match_unless)
+                had_edits = False
+                if args.only_edits:
+                    for edit in from_tree.get_all_edits(to_tree):
+                        printer.write(str(edit))
+                        printer.newline()
+                        had_edits = had_edits or edit.has_non_zero_cost()
+                elif args.edit_digest:
+                    if args.format is not None:
+                        formatter = graphtage.FILETYPES_BY_TYPENAME[args.format].get_default_formatter()
                     else:
-                        diff = from_tree.diff(to_tree)
-                        if args.format is not None:
-                            formatter = graphtage.FILETYPES_BY_TYPENAME[args.format].get_default_formatter()
-                        else:
-                            formatter = from_format.get_default_formatter()
-                        formatter.print(printer, diff)
-                        had_edits = any(any(e.has_non_zero_cost() for e in n.edit_list) for n in diff.dfs())
+                        formatter = from_format.get_default_formatter()
+
+                    for ancestors, edit in from_tree.get_all_edit_contexts(to_tree):
+                        for i, node in enumerate(ancestors):
+                            if node.parent is not None:
+                                node.parent.print_parent_context(printer, for_child=node)
+                            if i == len(ancestors) - 1:
+                                with printer.color(Fore.BLUE):
+                                    printer.write(" -> ")
+                                formatter.print(printer, edit)
+                        printer.newline()
+                        had_edits = had_edits or edit.has_non_zero_cost()
+                else:
+                    diff = from_tree.diff(to_tree)
+                    if args.format is not None:
+                        formatter = graphtage.FILETYPES_BY_TYPENAME[args.format].get_default_formatter()
+                    else:
+                        formatter = from_format.get_default_formatter()
+                    formatter.print(printer, diff)
+                    had_edits = any(any(e.has_non_zero_cost() for e in n.edit_list) for n in diff.dfs())
             printer.write('\n')
     except KeyboardInterrupt:
         return -2  # SIGINT

--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -6,14 +6,11 @@ import sys
 
 from colorama.ansi import Fore
 
-from . import expressions
-from . import graphtage
+from . import expressions, graphtage, version
 from . import printer as printermodule
-from . import version
 from .constraints import MatchIf, MatchUnless
 from .printer import HTMLPrinter, Printer, enable_ansi_support
 from .utils import Tempfile
-
 
 log = logging.getLogger('graphtage')
 

--- a/graphtage/ast.py
+++ b/graphtage/ast.py
@@ -3,7 +3,7 @@ Generic node types for representing abstract syntax trees.
 """
 from colorama import Fore
 
-from . import KeyValuePairNode, ListNode, Printer, TreeNode, DictNode, StringNode
+from . import DictNode, KeyValuePairNode, ListNode, Printer, StringNode, TreeNode
 from .dataclasses import DataClassNode
 from .sequences import SequenceFormatter
 

--- a/graphtage/bounds.py
+++ b/graphtage/bounds.py
@@ -173,7 +173,7 @@ class Range:
         return hash((self.lower_bound, self.upper_bound))
 
     def __add__(self, other):
-        if isinstance(other, int) or isinstance(other, Infinity):
+        if isinstance(other, (int, Infinity)):
             return Range(self.lower_bound + other, self.upper_bound + other)
         else:
             return Range(self.lower_bound + other.lower_bound, self.upper_bound + other.upper_bound)
@@ -182,7 +182,7 @@ class Range:
         return self + other
 
     def __sub__(self, other):
-        if isinstance(other, int) or isinstance(other, Infinity):
+        if isinstance(other, (int, Infinity)):
             return Range(self.lower_bound - other, self.upper_bound - other)
         else:
             return Range(self.lower_bound - other.lower_bound, self.upper_bound - other.upper_bound)

--- a/graphtage/bounds.py
+++ b/graphtage/bounds.py
@@ -24,8 +24,7 @@ Attributes:
 
 import logging
 from functools import wraps
-from typing import Iterable, Iterator, List, Optional, Tuple, TypeVar, Union
-from typing_extensions import Protocol
+from typing import Iterable, Iterator, List, Optional, Protocol, Tuple, TypeVar, Union
 
 from intervaltree import Interval, IntervalTree
 

--- a/graphtage/bounds.py
+++ b/graphtage/bounds.py
@@ -23,13 +23,13 @@ Attributes:
 """
 
 import logging
+from collections.abc import Iterable, Iterator
 from functools import wraps
-from typing import Iterable, Iterator, List, Optional, Protocol, Tuple, TypeVar, Union
+from typing import Protocol, TypeVar
 
 from intervaltree import Interval, IntervalTree
 
 from .fibonacci import FibonacciHeap
-
 
 log = logging.getLogger(__name__)
 
@@ -110,7 +110,7 @@ class Infinity:
 
 NEGATIVE_INFINITY: Infinity = Infinity(positive=False)
 POSITIVE_INFINITY = Infinity(positive=True)
-RangeValue = Union[int, Infinity]
+RangeValue = int | Infinity
 
 
 class Range:
@@ -382,8 +382,8 @@ def min_bounded(bounds: Iterator[B]) -> B:
     The objects are auto-tightened in the event that their ranges overlap and a definitive minimum does not exist.
 
     """
-    best_item: Optional[B] = None
-    best: Optional[BoundedComparator] = None
+    best_item: B | None = None
+    best: BoundedComparator | None = None
     for b in map(BoundedComparator, bounds):
         if best_item is None or b < best:
             best_item = b.bounded
@@ -399,7 +399,7 @@ def make_distinct(*bounded: Bounded):
     tree: IntervalTree = IntervalTree()
     # Use a max-heap (negative sizes) to find biggest intervals in O(log n)
     # Heap entries: (-size, id(interval), interval) - id breaks ties deterministically
-    size_heap: List[Tuple[int, int, Interval]] = []
+    size_heap: list[tuple[int, int, Interval]] = []
 
     for b in bounded:
         if not b.bounds().finite:
@@ -416,7 +416,7 @@ def make_distinct(*bounded: Bounded):
 
     while len(tree) > 1:
         # Pop from heap until we find a valid interval (still in tree)
-        biggest: Optional[Interval] = None
+        biggest: Interval | None = None
         while size_heap:
             neg_size, iv_id, candidate = heapq.heappop(size_heap)
             if iv_id in valid_intervals:
@@ -445,7 +445,7 @@ def make_distinct(*bounded: Bounded):
             continue
 
         # Find the biggest intersecting interval (linear search over smaller set)
-        second_biggest: Optional[Interval] = None
+        second_biggest: Interval | None = None
         for m in matching:
             m_size = m.end - m.begin
             if second_biggest is None or m_size > second_biggest.end - second_biggest.begin:

--- a/graphtage/builder.py
+++ b/graphtage/builder.py
@@ -54,9 +54,9 @@ class Builder(ABC):
     def expander(node_type: type[T]):
         def wrapper(func: Callable[[C, T], Iterable[Any]]) -> Callable[[C, T], Iterable[Any]]:
             if hasattr(func, "_visitor_expander_for_type"):
-                func._visitor_expander_for_type = func._visitor_expander_for_type + (node_type,)
+                func._visitor_expander_for_type = (*func._visitor_expander_for_type, node_type)
             else:
-                setattr(func, "_visitor_expander_for_type", (node_type,))
+                func._visitor_expander_for_type = (node_type,)
             return func
 
         return wrapper
@@ -65,9 +65,9 @@ class Builder(ABC):
     def builder(node_type: type[T]):
         def wrapper(func: Callable[[C, T, list[TreeNode]], TreeNode]) -> Callable[[C, T, list[TreeNode]], TreeNode]:
             if hasattr(func, "_visitor_builder_for_type"):
-                func._visitor_builder_for_type = func._visitor_builder_for_type + (node_type,)
+                func._visitor_builder_for_type = (*func._visitor_builder_for_type, node_type)
             else:
-                setattr(func, "_visitor_builder_for_type", (node_type,))
+                func._visitor_builder_for_type = (node_type,)
             return func
 
         return wrapper
@@ -75,18 +75,18 @@ class Builder(ABC):
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         if not hasattr(cls, "EXPANDERS") or cls.EXPANDERS is None:
-            setattr(cls, "EXPANDERS", {})
+            cls.EXPANDERS = {}
         else:
-            setattr(cls, "EXPANDERS", dict(cls.EXPANDERS))
+            cls.EXPANDERS = dict(cls.EXPANDERS)
         if not hasattr(cls, "BUILDERS") or cls.BUILDERS is None:
-            setattr(cls, "BUILDERS", {})
+            cls.BUILDERS = {}
         else:
-            setattr(cls, "BUILDERS", dict(cls.BUILDERS))
+            cls.BUILDERS = dict(cls.BUILDERS)
         new_expanders = {}
         new_builders = {}
         for member_name, member in cls.__dict__.items():
             if hasattr(member, "_visitor_expander_for_type"):
-                for expander_type in getattr(member, "_visitor_expander_for_type"):
+                for expander_type in member._visitor_expander_for_type:
                     if not isinstance(expander_type, type):
                         raise TypeError(f"{cls.__name__}.{member_name} was registered as an expander for "
                                         f"{expander_type!r}, which is not a type")
@@ -100,7 +100,7 @@ class Builder(ABC):
                                         f"{cls.__name__}.{member_name}")
                     new_expanders[expander_type] = member
             if hasattr(member, "_visitor_builder_for_type"):
-                for builder_type in getattr(member, "_visitor_builder_for_type"):
+                for builder_type in member._visitor_builder_for_type:
                     if not isinstance(builder_type, type):
                         raise TypeError(f"{cls.__name__}.{member_name} was registered as an builder for "
                                         f"{builder_type!r}, which is not a type")
@@ -164,7 +164,6 @@ class Builder(ABC):
     def build_tree(self, root_obj) -> TreeNode:
         children = self.expand(root_obj)
         work: list[tuple[Any, list[TreeNode], list[Any]]] = [(root_obj, [], list(reversed(list(children))))]
-        basic_builder = BasicBuilder(self.options)
         with self.options.printer.tqdm(
                 desc="Walking the Tree", leave=False, delay=2.0, unit=" nodes", total=1 + len(work[-1][-1])
         ) as t:
@@ -271,10 +270,7 @@ class BasicBuilder(Builder):
         n = len(children) // 2
         keys = children[:n]
         values = children[n:]
-        dict_items = {
-            k: v
-            for k, v in zip(keys, values)
-        }
+        dict_items = dict(zip(keys, values, strict=True))
         if self.options.allow_key_edits:
             dict_node = DictNode.from_dict(dict_items)
             dict_node.auto_match_keys = self.options.auto_match_keys

--- a/graphtage/builder.py
+++ b/graphtage/builder.py
@@ -1,12 +1,24 @@
 """A module intended to simplify building Graphtage IR trees from other tree-like data structures."""
 
-from abc import ABC
 import logging
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, TypeVar
+from abc import ABC
+from collections.abc import Callable, Iterable
+from typing import Any, TypeVar
 
 from . import (
-    BoolNode, BuildOptions, DictNode, FixedKeyDictNode, FloatNode, IntegerNode, LeafNode, ListNode, MultiSetNode,
-    NullNode, StringNode, TreeNode, UnorderedListNode
+    BoolNode,
+    BuildOptions,
+    DictNode,
+    FixedKeyDictNode,
+    FloatNode,
+    IntegerNode,
+    LeafNode,
+    ListNode,
+    MultiSetNode,
+    NullNode,
+    StringNode,
+    TreeNode,
+    UnorderedListNode,
 )
 from .object_set import IdentityHash
 from .sequences import SequenceNode
@@ -29,17 +41,17 @@ class CyclicReference(LeafNode):
 
 
 class Builder(ABC):
-    EXPANDERS: Dict[Type[Any], Callable[["Builder", Any], Optional[Iterable[Any]]]]
-    BUILDERS: Dict[Type[Any], Callable[["Builder", Any, List[TreeNode]], TreeNode]]
+    EXPANDERS: dict[type[Any], Callable[["Builder", Any], Iterable[Any] | None]]
+    BUILDERS: dict[type[Any], Callable[["Builder", Any, list[TreeNode]], TreeNode]]
 
-    def __init__(self, options: Optional[BuildOptions] = None):
+    def __init__(self, options: BuildOptions | None = None):
         if options is None:
             self.options: BuildOptions = BuildOptions()
         else:
             self.options = options
 
     @staticmethod
-    def expander(node_type: Type[T]):
+    def expander(node_type: type[T]):
         def wrapper(func: Callable[[C, T], Iterable[Any]]) -> Callable[[C, T], Iterable[Any]]:
             if hasattr(func, "_visitor_expander_for_type"):
                 func._visitor_expander_for_type = func._visitor_expander_for_type + (node_type,)
@@ -50,8 +62,8 @@ class Builder(ABC):
         return wrapper
 
     @staticmethod
-    def builder(node_type: Type[T]):
-        def wrapper(func: Callable[[C, T, List[TreeNode]], TreeNode]) -> Callable[[C, T, List[TreeNode]], TreeNode]:
+    def builder(node_type: type[T]):
+        def wrapper(func: Callable[[C, T, list[TreeNode]], TreeNode]) -> Callable[[C, T, list[TreeNode]], TreeNode]:
             if hasattr(func, "_visitor_builder_for_type"):
                 func._visitor_builder_for_type = func._visitor_builder_for_type + (node_type,)
             else:
@@ -107,11 +119,11 @@ class Builder(ABC):
     def default_expander(self, node: Any) -> Iterable[Any]:
         return ()
 
-    def default_builder(self, node: Any, children: List[TreeNode]) -> TreeNode:
+    def default_builder(self, node: Any, children: list[TreeNode]) -> TreeNode:
         raise NotImplementedError(f"A builder for type {node.__class__.__name__} is not defined for object {node!r}")
 
     @classmethod
-    def _resolve(cls, obj_type: Type[Any], choices: Dict[Type[Any], T]) -> Optional[T]:
+    def _resolve(cls, obj_type: type[Any], choices: dict[type[Any], T]) -> T | None:
         """Resolves the most specialized expander or builder for `obj_type`"""
         for t in obj_type.__mro__:
             if t in choices:
@@ -119,12 +131,12 @@ class Builder(ABC):
         return None
 
     @classmethod
-    def resolve_expander(cls, obj_type: Type[Any]) -> Optional[Callable[[Any], Optional[Iterable[Any]]]]:
+    def resolve_expander(cls, obj_type: type[Any]) -> Callable[[Any], Iterable[Any] | None] | None:
         """Resolves the most specialized expander for `obj_type`"""
         return cls._resolve(obj_type, cls.EXPANDERS)
 
     @classmethod
-    def resolve_builder(cls, obj_type: Type[Any]) -> Optional[Callable[[Any, List[TreeNode]], TreeNode]]:
+    def resolve_builder(cls, obj_type: type[Any]) -> Callable[[Any, list[TreeNode]], TreeNode] | None:
         """Resolves the most specialized builder for `obj_type`"""
         return cls._resolve(obj_type, cls.BUILDERS)
 
@@ -134,7 +146,7 @@ class Builder(ABC):
             return self.default_expander(node)
         return expander(self, node)
 
-    def build(self, node: Any, children: List[TreeNode]) -> TreeNode:
+    def build(self, node: Any, children: list[TreeNode]) -> TreeNode:
         builder = self.resolve_builder(type(node))
         if builder is None:
             result = self.default_builder(node, children)
@@ -151,7 +163,7 @@ class Builder(ABC):
 
     def build_tree(self, root_obj) -> TreeNode:
         children = self.expand(root_obj)
-        work: List[Tuple[Any, List[TreeNode], List[Any]]] = [(root_obj, [], list(reversed(list(children))))]
+        work: list[tuple[Any, list[TreeNode], list[Any]]] = [(root_obj, [], list(reversed(list(children))))]
         basic_builder = BasicBuilder(self.options)
         with self.options.printer.tqdm(
                 desc="Walking the Tree", leave=False, delay=2.0, unit=" nodes", total=1 + len(work[-1][-1])
@@ -235,7 +247,7 @@ class BasicBuilder(Builder):
 
     @Builder.builder(list)
     @Builder.builder(tuple)
-    def build_list(self, obj, children: List[TreeNode]) -> SequenceNode:
+    def build_list(self, obj, children: list[TreeNode]) -> SequenceNode:
         if self.options.ignore_list_order:
             return UnorderedListNode(children, auto_match_keys=self.options.auto_match_keys)
         return ListNode(
@@ -246,7 +258,7 @@ class BasicBuilder(Builder):
 
     @Builder.builder(set)
     @Builder.builder(frozenset)
-    def build_set(self, obj, children: List[TreeNode]) -> MultiSetNode:
+    def build_set(self, obj, children: list[TreeNode]) -> MultiSetNode:
         return MultiSetNode(children)
 
     @Builder.expander(dict)
@@ -255,7 +267,7 @@ class BasicBuilder(Builder):
         yield from obj.values()
 
     @Builder.builder(dict)
-    def build_dict(self, _, children: List[TreeNode]):
+    def build_dict(self, _, children: list[TreeNode]):
         n = len(children) // 2
         keys = children[:n]
         values = children[n:]

--- a/graphtage/constraints.py
+++ b/graphtage/constraints.py
@@ -1,10 +1,8 @@
-from abc import ABCMeta, abstractmethod
 import logging
-from typing import Optional
+from abc import ABCMeta, abstractmethod
 
+from . import expressions, graphtage
 from .edits import Edit
-from . import expressions
-from . import graphtage
 
 log = logging.getLogger('graphtage')
 
@@ -14,7 +12,7 @@ class ConditionalMatcher(metaclass=ABCMeta):
         self.condition: expressions.Expression = condition
 
     @abstractmethod
-    def __call__(self, from_node: graphtage.TreeNode, to_node: graphtage.TreeNode) -> Optional[Edit]:
+    def __call__(self, from_node: graphtage.TreeNode, to_node: graphtage.TreeNode) -> Edit | None:
         raise NotImplementedError()
 
     @classmethod
@@ -23,7 +21,7 @@ class ConditionalMatcher(metaclass=ABCMeta):
 
 
 class MatchIf(ConditionalMatcher):
-    def __call__(self, from_node: graphtage.TreeNode, to_node: graphtage.TreeNode) -> Optional[Edit]:
+    def __call__(self, from_node: graphtage.TreeNode, to_node: graphtage.TreeNode) -> Edit | None:
         try:
             if self.condition.eval(locals={'from': from_node, 'to': to_node}):
                 return None
@@ -33,7 +31,7 @@ class MatchIf(ConditionalMatcher):
 
 
 class MatchUnless(ConditionalMatcher):
-    def __call__(self, from_node: graphtage.TreeNode, to_node: graphtage.TreeNode) -> Optional[Edit]:
+    def __call__(self, from_node: graphtage.TreeNode, to_node: graphtage.TreeNode) -> Edit | None:
         try:
             if self.condition.eval(locals={'from': from_node.to_obj(), 'to': to_node.to_obj()}):
                 return graphtage.Replace(from_node, to_node)

--- a/graphtage/csv.py
+++ b/graphtage/csv.py
@@ -7,7 +7,6 @@
 
 import csv
 from io import StringIO
-from typing import Optional
 
 from . import graphtage, json
 from .json import JSONFormatter
@@ -31,7 +30,7 @@ class CSVNode(graphtage.ListNode[CSVRow]):
         return self._children == other._children or (not self and not other)
 
 
-def build_tree(path: str, options: Optional[graphtage.BuildOptions] = None, *args, **kwargs) -> CSVNode:
+def build_tree(path: str, options: graphtage.BuildOptions | None = None, *args, **kwargs) -> CSVNode:
     """Constructs a :class:`CSVNode` from a CSV file.
 
     The file is parsed using Python's :func:`csv.reader`. The elements in each row are constructed by delegating to
@@ -165,11 +164,11 @@ class CSV(graphtage.Filetype):
             'text/csv'
         )
 
-    def build_tree(self, path: str, options: Optional[graphtage.BuildOptions] = None) -> TreeNode:
+    def build_tree(self, path: str, options: graphtage.BuildOptions | None = None) -> TreeNode:
         """Equivalent to :func:`build_tree`"""
         return build_tree(path, options=options)
 
-    def build_tree_handling_errors(self, path: str, options: Optional[graphtage.BuildOptions] = None) -> TreeNode:
+    def build_tree_handling_errors(self, path: str, options: graphtage.BuildOptions | None = None) -> TreeNode:
         return self.build_tree(path=path, options=options)
 
     def get_default_formatter(self) -> CSVFormatter:

--- a/graphtage/csv.py
+++ b/graphtage/csv.py
@@ -92,7 +92,7 @@ class CSVRows(SequenceFormatter):
     """A sub formatter for printing the sequence of rows in a CSV file."""
     is_partial = True
 
-    sub_format_types = [CSVRowFormatter]
+    sub_format_types = (CSVRowFormatter,)
 
     def __init__(self):
         """Initializes the formatter.
@@ -126,7 +126,7 @@ class CSVRows(SequenceFormatter):
 
 class CSVFormatter(GraphtageFormatter):
     """Top-level formatter for CSV files."""
-    sub_format_types = [CSVRows, JSONFormatter]
+    sub_format_types = (CSVRows, JSONFormatter)
 
     def print_LeafNode(self, printer: Printer, node: graphtage.LeafNode):
         """Prints a leaf node, which should always be a column in a CSV row.

--- a/graphtage/dataclasses.py
+++ b/graphtage/dataclasses.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from typing import get_origin
 
 from . import AbstractCompoundEdit, Edit, Range, Replace
 from .printer import Fore, Printer
@@ -27,10 +28,7 @@ class DataClassEdit(AbstractCompoundEdit):
         yield from self.slot_edits
 
     def tighten_bounds(self) -> bool:
-        for edit in self.slot_edits:
-            if edit.tighten_bounds():
-                return True
-        return False
+        return any(edit.tighten_bounds() for edit in self.slot_edits)
 
 
 class DataClassNode(ContainerNode):
@@ -106,7 +104,11 @@ class DataClassNode(ContainerNode):
         else:
             cls._SLOT_ANNOTATIONS = dict(cls._SLOT_ANNOTATIONS)
         new_slots = []
-        for i, (name, slot_type) in enumerate(cls.__annotations__.items()):
+        for name, slot_type in cls.__annotations__.items():
+            # get_origin() screens out subscripted generics before issubclass() sees them. On Python
+            # 3.10 isinstance(list[int], type) is True, so issubclass() would raise there.
+            if get_origin(slot_type) is not None:
+                continue
             if not isinstance(slot_type, type) or not issubclass(slot_type, TreeNode):
                 continue
             if name in ancestor_slot_names:

--- a/graphtage/dataclasses.py
+++ b/graphtage/dataclasses.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterator, List, Tuple, Type
+from collections.abc import Iterator
 
 from . import AbstractCompoundEdit, Edit, Range, Replace
 from .printer import Fore, Printer
@@ -11,7 +11,7 @@ class DataClassEdit(AbstractCompoundEdit):
         to_slots = dict(to_node.items())
         if from_slots.keys() != to_slots.keys():
             raise ValueError(f"Node {from_node!r} cannot be edited to {to_node!r} because they have incompatible slots")
-        self.slot_edits: List[Edit] = [
+        self.slot_edits: list[Edit] = [
             value.edits(to_slots[slot])
             for slot, value in from_slots.items()
         ]
@@ -36,9 +36,9 @@ class DataClassEdit(AbstractCompoundEdit):
 class DataClassNode(ContainerNode):
     """A container node that can be initialized similar to a Python :func:`dataclasses.dataclass`"""
 
-    _SLOTS: Tuple[str, ...]
-    _SLOT_ANNOTATIONS: Dict[str, Type[TreeNode]]
-    _DATA_CLASS_ANCESTORS: List[Type["DataClassNode"]]
+    _SLOTS: tuple[str, ...]
+    _SLOT_ANNOTATIONS: dict[str, type[TreeNode]]
+    _DATA_CLASS_ANCESTORS: list[type["DataClassNode"]]
 
     def __init__(self, *args, **kwargs):
         """Be careful extending __init__; consider using :func:`DataClassNode.post_init` instead."""
@@ -123,7 +123,7 @@ class DataClassNode(ContainerNode):
         for _, value in self.items():
             yield value
 
-    def items(self) -> Iterator[Tuple[str, TreeNode]]:
+    def items(self) -> Iterator[tuple[str, TreeNode]]:
         for slot in self._SLOTS:
             yield slot, getattr(self, slot)
 

--- a/graphtage/edits.py
+++ b/graphtage/edits.py
@@ -14,8 +14,13 @@ class AbstractEdit(Debuggable, Edit, ABC):
     """Abstract base class for the :class:`Edit` protocol."""
 
     __slots__ = (
-        'from_node', 'to_node', '_constant_cost', '_cost_upper_bound',
-        '_valid', 'initial_bounds', '_checking_bounds'
+        '_checking_bounds',
+        '_constant_cost',
+        '_cost_upper_bound',
+        '_valid',
+        'from_node',
+        'initial_bounds',
+        'to_node'
     )
 
     def __init__(self,
@@ -42,9 +47,9 @@ class AbstractEdit(Debuggable, Edit, ABC):
         self._cached_bounds: Range | None = None
         self.initial_bounds = self.bounds()
         """The initial bounds of this edit.
-         
+
          This is automatically set by calling :meth:`self.bounds()<AbstractEdit.bounds>` during initialization.
-         
+
          """
 
     def _debug_tighten_bounds(self) -> bool:
@@ -71,19 +76,19 @@ class AbstractEdit(Debuggable, Edit, ABC):
         if name in ("bounds", "__getattribute__", "tighten_bounds", "_original_tighten_bounds", "_checking_bounds") \
                 or (hasattr(self, "_checking_bounds") and self._checking_bounds):
             checking_before = hasattr(self, "_checking_bounds") and self._checking_bounds
-            setattr(self, "_checking_bounds", True)
+            self._checking_bounds = True
             try:
                 return method(*args, **kwargs)
             finally:
-                setattr(self, "_checking_bounds", checking_before)
+                self._checking_bounds = checking_before
 
-        setattr(self, "_checking_bounds", True)
+        self._checking_bounds = True
         try:
             bounds_before = self.bounds()
             new_result = method(*args, **kwargs)
             new_bounds = self.bounds()
         finally:
-            setattr(self, "_checking_bounds", False)
+            self._checking_bounds = False
         if new_bounds != bounds_before:
             print(f"Error: Bounds before calling {self!r}.{name}(*{args!r}, **{kwargs!r}) were {bounds_before!s} "
                   f"but {new_bounds!s} after")
@@ -307,14 +312,12 @@ class Match(ConstantCostEdit):
 
     def print(self, formatter: GraphtageFormatter, printer: Printer):
         if self.bounds() > Range(0, 0):
-            with printer.bright().background(Back.RED).color(Fore.WHITE):
-                with printer.strike():
-                    formatter.print(printer=printer, node_or_edit=self.from_node, with_edits=False)
+            with printer.bright().background(Back.RED).color(Fore.WHITE), printer.strike():
+                formatter.print(printer=printer, node_or_edit=self.from_node, with_edits=False)
             with printer.color(Fore.CYAN):
                 printer.write(' -> ')
-            with printer.bright().background(Back.GREEN).color(Fore.WHITE):
-                with printer.under_plus():
-                    formatter.print(printer=printer, node_or_edit=self.to_node, with_edits=False)
+            with printer.bright().background(Back.GREEN).color(Fore.WHITE), printer.under_plus():
+                formatter.print(printer=printer, node_or_edit=self.to_node, with_edits=False)
         else:
             formatter.print(printer=printer, node_or_edit=self.to_node, with_edits=False)
 
@@ -371,16 +374,14 @@ class Remove(ConstantCostEdit):
         from_node.removed = True
 
     def print(self, formatter: GraphtageFormatter, printer: Printer):
-        with printer.bright():
-            with printer.background(Back.RED):
-                with printer.color(Fore.WHITE):
-                    if not printer.ansi_color:
-                        printer.write(self.REMOVE_STRING)
-                        formatter.print(printer, self.from_node, False)
-                        printer.write(self.REMOVE_STRING)
-                    else:
-                        with printer.strike():
-                            formatter.print(printer, self.from_node, False)
+        with printer.bright(), printer.background(Back.RED), printer.color(Fore.WHITE):
+            if not printer.ansi_color:
+                printer.write(self.REMOVE_STRING)
+                formatter.print(printer, self.from_node, False)
+                printer.write(self.REMOVE_STRING)
+            else:
+                with printer.strike():
+                    formatter.print(printer, self.from_node, False)
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.from_node!r}, remove_from={self.to_node!r})"
@@ -433,7 +434,7 @@ C = TypeVar('C', bound=Collection)
 class EditCollection(AbstractCompoundEdit, Generic[C]):
     """An edit comprised of one or more sub-edits."""
 
-    __slots__ = ('_edit_iter', '_sub_edits', '_cost', 'explode_edits', '_add')
+    __slots__ = ('_add', '_cost', '_edit_iter', '_sub_edits', 'explode_edits')
 
     def __init__(
             self,

--- a/graphtage/edits.py
+++ b/graphtage/edits.py
@@ -1,11 +1,12 @@
-from abc import abstractmethod, ABC
 import itertools
-from typing import Any, Callable, cast, Collection, Generic, Iterator, List, Optional, Type, TypeVar
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Collection, Iterator
+from typing import Any, Generic, TypeVar, cast
 
+from .bounds import Range
 from .debug import Debuggable
 from .printer import Back, Fore, Printer
 from .search import IterativeTighteningSearch
-from .bounds import Range
 from .tree import CompoundEdit, Edit, EditedTreeNode, GraphtageFormatter, TreeNode
 
 
@@ -20,8 +21,8 @@ class AbstractEdit(Debuggable, Edit, ABC):
     def __init__(self,
                  from_node: TreeNode,
                  to_node: TreeNode = None,
-                 constant_cost: Optional[int] = 0,
-                 cost_upper_bound: Optional[int] = None):
+                 constant_cost: int | None = 0,
+                 cost_upper_bound: int | None = None):
         """Constructs a new Edit.
 
         Args:
@@ -38,7 +39,7 @@ class AbstractEdit(Debuggable, Edit, ABC):
         self._constant_cost = constant_cost
         self._cost_upper_bound = cost_upper_bound
         self._valid: bool = True
-        self._cached_bounds: Optional[Range] = None
+        self._cached_bounds: Range | None = None
         self.initial_bounds = self.bounds()
         """The initial bounds of this edit.
          
@@ -233,7 +234,7 @@ class PossibleEdits(AbstractCompoundEdit):
             from_node: TreeNode,
             to_node: TreeNode,
             edits: Iterator[Edit] = (),
-            initial_cost: Optional[Range] = None
+            initial_cost: Range | None = None
     ):
         """Constructs a new Possible Edits object.
 
@@ -269,7 +270,7 @@ class PossibleEdits(AbstractCompoundEdit):
     def valid(self, is_valid: bool):
         self._valid = is_valid
 
-    def best_possibility(self) -> Optional[Edit]:
+    def best_possibility(self) -> Edit | None:
         """Returns the best possibility as of yet."""
         return self._search.best_match
 
@@ -437,8 +438,8 @@ class EditCollection(AbstractCompoundEdit, Generic[C]):
     def __init__(
             self,
             from_node: TreeNode,
-            to_node: Optional[TreeNode],
-            collection: Type[C],
+            to_node: TreeNode | None,
+            collection: type[C],
             add_to_collection: Callable[[C, Edit], Any],
             edits: Iterator[Edit],
             explode_edits: bool = True
@@ -477,7 +478,7 @@ class EditCollection(AbstractCompoundEdit, Generic[C]):
         for sub_edit in self.edits():
             sub_edit.print(formatter, printer)
 
-    def _expand_edits(self) -> Optional[Edit]:
+    def _expand_edits(self) -> Edit | None:
         if self._edit_iter is not None:
             try:
                 next_edit = next(self._edit_iter)
@@ -559,7 +560,7 @@ class EditCollection(AbstractCompoundEdit, Generic[C]):
         return f"{self.__class__.__name__}(*{self._sub_edits!r})"
 
 
-class EditSequence(EditCollection[List]):
+class EditSequence(EditCollection[list]):
     """An :class:`EditCollection` using a :class:`list` as the underlying container."""
 
     __slots__ = ()
@@ -567,7 +568,7 @@ class EditSequence(EditCollection[List]):
     def __init__(
             self,
             from_node: TreeNode,
-            to_node: Optional[TreeNode],
+            to_node: TreeNode | None,
             edits: Iterator[Edit],
             explode_edits: bool = True
     ):

--- a/graphtage/expressions.py
+++ b/graphtage/expressions.py
@@ -36,15 +36,21 @@ Attributes:
 
 """
 
+import itertools
 from collections import deque
+from collections.abc import Callable, Collection, Iterable, Iterator
 from enum import Enum
 from io import StringIO
-from typing import Any, Callable, Collection, Dict, Generic, IO, Iterable, Iterator, List, Optional, Set, \
-    SupportsFloat, SupportsInt, Tuple, Type, TypeVar, Union
-import itertools
+from typing import (
+    IO,
+    Any,
+    Generic,
+    SupportsFloat,
+    SupportsInt,
+    TypeVar,
+)
 
-
-DEFAULT_GLOBALS: Dict[str, Any] = {
+DEFAULT_GLOBALS: dict[str, Any] = {
     obj.__name__: obj for obj in (
         str, bool, int, bytes, float, bytearray, dict, set, frozenset,
         enumerate, zip, map, filter, any, all, chr, ord, abs, ascii, bin, bool, complex, hash, hex, oct, min, max, id,
@@ -53,7 +59,7 @@ DEFAULT_GLOBALS: Dict[str, Any] = {
 }
 
 
-OPERATORS_BY_NAME: Dict[str, 'Operator'] = {}
+OPERATORS_BY_NAME: dict[str, 'Operator'] = {}
 
 
 class ParseError(RuntimeError):
@@ -139,7 +145,7 @@ class Operator(Enum):
                  is_left_associative: bool = True,
                  arity: int = 2,
                  include_in_global_operator_table: bool = False,
-                 expand: Optional[Tuple[bool, ...]] = None):
+                 expand: tuple[bool, ...] | None = None):
         """Initializes an operator enum.
 
         Raises:
@@ -163,15 +169,15 @@ class Operator(Enum):
         self.arity: int = arity
         """The number of arguments consumed by the operator."""
         if expand is None:
-            self.expand: Tuple[bool, ...] = (True,) * self.arity
+            self.expand: tuple[bool, ...] = (True,) * self.arity
             """Whether each of the operator's arguments should be auto-expanded before execution."""
         else:
-            self.expand: Tuple[bool, ...] = expand
+            self.expand: tuple[bool, ...] = expand
         if not include_in_global_operator_table:
             OPERATORS_BY_NAME[self.token] = self
 
 
-IDENTIFIER_BYTES: Set[str] = {
+IDENTIFIER_BYTES: set[str] = {
     chr(i) for i in range(ord('A'), ord('Z') + 1)
 } | {
     chr(i) for i in range(ord('a'), ord('z') + 1)
@@ -239,7 +245,7 @@ class PairedEndToken(PairedToken):
     Examples include "]" and ")".
 
     """
-    start_token_type: Type[PairedStartToken] = None
+    start_token_type: type[PairedStartToken] = None
 
 
 class Parenthesis(Token):
@@ -272,7 +278,7 @@ class CloseParen(Parenthesis, PairedEndToken):
 
 class OperatorToken(Token):
     """A token associated with an :class:`Operator`."""
-    def __init__(self, op: Union[str, Operator], offset: int):
+    def __init__(self, op: str | Operator, offset: int):
         if isinstance(op, str):
             op = OPERATORS_BY_NAME[op]
         super().__init__(op.token, offset)
@@ -325,11 +331,11 @@ class FixedSizeCollection(Token):
     This is used for parsing and evaluating argument lists of functions of unknown arity.
 
     """
-    def __init__(self, size: int, container_type: Type[Collection], offset: int):
+    def __init__(self, size: int, container_type: type[Collection], offset: int):
         super().__init__(container_type.__name__, offset)
         self.size: int = size
         """The number of items on the stack to include."""
-        self.container_type: Type[Collection] = container_type
+        self.container_type: type[Collection] = container_type
         """The type of collection in which to store the items."""
 
     def __repr__(self):
@@ -344,7 +350,7 @@ class IdentifierToken(Token):
         """The name of this identifier"""
 
 
-N = TypeVar('N', bound=Union[SupportsInt, SupportsFloat])
+N = TypeVar('N', bound=SupportsInt | SupportsFloat)
 
 
 class NumericToken(Token, Generic[N]):
@@ -392,7 +398,7 @@ class FunctionCall(OperatorToken):
 
 class Tokenizer:
     """The expression tokenizer."""
-    def __init__(self, stream: Union[str, IO]):
+    def __init__(self, stream: str | IO):
         """Initializes a tokenizer, but does not commence any tokenization.
 
         Args:
@@ -403,11 +409,11 @@ class Tokenizer:
             stream = StringIO(stream)
         self._stream: IO = stream
         self._buffer: deque = deque()
-        self._next_token: Optional[Token] = None
-        self.prev_token: Optional[Token] = None
+        self._next_token: Token | None = None
+        self.prev_token: Token | None = None
         """The previous token yielded by this tokenizer."""
         self._offset: int = 0
-        self._function_parens: List[bool] = []
+        self._function_parens: list[bool] = []
 
     def _peek_byte(self, n=1) -> str:
         bytes_needed = n - len(self._buffer)
@@ -425,7 +431,7 @@ class Tokenizer:
         self._offset += len(ret)
         return ret
 
-    def peek(self) -> Optional[Token]:
+    def peek(self) -> Token | None:
         """Returns the next token that would be returned from a call to :meth:`Tokenizer.next`.
 
         This function actually computes and caches the next token if it has not already been cached.
@@ -439,9 +445,9 @@ class Tokenizer:
             return self._next_token
         elif isinstance(self.prev_token, FunctionCall):
             return OpenParen(self.prev_token.offset, is_function_call=True)
-        ret: Optional[Token] = None
-        operand: Optional[str] = None
-        string_start: Optional[str] = None
+        ret: Token | None = None
+        operand: str | None = None
+        string_start: str | None = None
         string_start_pos: int = 0
         # ignore leading whitespace
         while self._peek_byte() == ' ' or self._peek_byte() == '\t':
@@ -566,7 +572,7 @@ class Tokenizer:
         """
         return self.peek() is not None
 
-    def next(self) -> Optional[Token]:
+    def next(self) -> Token | None:
         """Returns the next token in the stream.
 
         Returns:
@@ -587,7 +593,7 @@ class Tokenizer:
             yield ret
 
 
-def tokenize(stream_or_str: Union[IO, str]) -> Iterator[Token]:
+def tokenize(stream_or_str: IO | str) -> Iterator[Token]:
     """Convenience function for tokenizing a string.
 
     This is equivalent to::
@@ -600,16 +606,16 @@ def tokenize(stream_or_str: Union[IO, str]) -> Iterator[Token]:
 
 class CollectionInfo:
     """A datastructure used by the :func:`infix_to_rpn` function to keep track of list and tuple semantics."""
-    def __init__(self, collection_type: Union[Type[tuple], Type[list]]):
+    def __init__(self, collection_type: type[tuple] | type[list]):
         self.num_commas: int = 0
-        self.collection_type: Union[Type[tuple], Type[list]] = collection_type
+        self.collection_type: type[tuple] | type[list] = collection_type
         self.last_was_comma: bool = False
 
 
 def infix_to_rpn(tokens: Iterable[Token]) -> Iterator[Token]:
     """Converts an infix expression to reverse Polish notation using the Shunting Yard algorithm."""
-    operators: List[OperatorToken] = []
-    collection_stack: List[CollectionInfo] = []
+    operators: list[OperatorToken] = []
+    collection_stack: list[CollectionInfo] = []
 
     for token in tokens:
         if isinstance(token, Comma):
@@ -627,7 +633,7 @@ def infix_to_rpn(tokens: Iterable[Token]) -> Iterator[Token]:
             else:
                 raise NotImplementedError(f"Add support for tokens of type {type(token)}")
         elif isinstance(token, PairedEndToken):
-            looking_for: Type[PairedStartToken] = token.start_token_type
+            looking_for: type[PairedStartToken] = token.start_token_type
             while operators and not isinstance(operators[-1], looking_for):
                 if isinstance(operators[-1], PairedStartToken):
                     raise ParseError(f"{token.name} mismatched with a {operators[-1].name}", token.offset)
@@ -686,10 +692,10 @@ class Expression:
 
     """
     def __init__(self, rpn: Iterable[Token]):
-        self.tokens: Tuple[Token, ...] = tuple(rpn)
+        self.tokens: tuple[Token, ...] = tuple(rpn)
 
     @staticmethod
-    def get_value(token: Token, locals: Dict[str, Any], globals: Dict[str, Any]):
+    def get_value(token: Token, locals: dict[str, Any], globals: dict[str, Any]):
         """Determines the value of a token given the provided state.
 
         Literal tokens like :class:`NumericToken` and :class:`StringToken` will return their values, and identifiers
@@ -726,7 +732,7 @@ class Expression:
         else:
             return token
 
-    def eval(self, locals: Optional[Dict[str, Any]] = None, globals: Optional[Dict[str, Any]] = None):
+    def eval(self, locals: dict[str, Any] | None = None, globals: dict[str, Any] | None = None):
         """Evaluates this expression given the provided state.
 
         Args:
@@ -740,10 +746,10 @@ class Expression:
 
         """
         if locals is None:
-            locals: Dict[str, Any] = {}
+            locals: dict[str, Any] = {}
         if globals is None:
-            globals: Dict[str, Any] = DEFAULT_GLOBALS
-        values: List[Any] = []
+            globals: dict[str, Any] = DEFAULT_GLOBALS
+        values: list[Any] = []
         for t in self.tokens:
             if isinstance(t, FixedSizeCollection):
                 args = [

--- a/graphtage/expressions.py
+++ b/graphtage/expressions.py
@@ -157,7 +157,7 @@ class Operator(Enum):
             raise ValueError("Operators of length greater than three are currently not supported by the tokenizer.")
         self.token: str = token
         """The token string associated with this operator. It is used for automatically parsing the operators.
-        
+
         Tokens must be unique. There is no programmatic check to ensure this.
         """
         self.priority: int = priority
@@ -481,8 +481,9 @@ class Tokenizer:
 
                 # An opening bracket indicates creating a list (rather than a getitem) if it follows a comma
                 # or '[' or '(' or an operator
-                is_list = self.prev_token is None or isinstance(self.prev_token, Comma) \
-                          or isinstance(self.prev_token, PairedStartToken) or isinstance(self.prev_token, OperatorToken)
+                is_list = self.prev_token is None or isinstance(
+                    self.prev_token, (Comma, PairedStartToken, OperatorToken)
+                )
                 ret = OpenBracket(self._offset, is_list=is_list)
             elif c[0] == ',':
                 # we also have to check this before the operators for the same reason as '[' above:
@@ -505,8 +506,7 @@ class Tokenizer:
                 else:
                     ret = OperatorToken(c[0], self._offset)
             elif c[0] == '(':
-                if isinstance(self.prev_token, IdentifierToken) \
-                        or isinstance(self.prev_token, PairedEndToken):
+                if isinstance(self.prev_token, (IdentifierToken, PairedEndToken)):
                     # Inject a function call before the parenthesis
                     # We will emit the OpenParen token on the next call to peek()
                     ret = FunctionCall(self._offset)
@@ -755,15 +755,15 @@ class Expression:
                 args = [
                     self.get_value(arg, locals, globals) for arg in values[-t.size:]
                 ]
-                values = values[:-t.size] + [t.container_type(args)]
+                values = [*values[:-t.size], t.container_type(args)]
             elif isinstance(t, OperatorToken):
                 args = []
-                for expand, v in zip(t.op.expand, values[-t.op.arity:]):
+                for expand, v in zip(t.op.expand, values[-t.op.arity:], strict=True):
                     if expand:
                         args.append(self.get_value(v, locals, globals))
                     else:
                         args.append(v)
-                values = values[:-t.op.arity] + [t.op.execute(*args)]
+                values = [*values[:-t.op.arity], t.op.execute(*args)]
             else:
                 values.append(t)
         if len(values) != 1:

--- a/graphtage/expressions.py
+++ b/graphtage/expressions.py
@@ -437,7 +437,7 @@ class Tokenizer:
         This function actually computes and caches the next token if it has not already been cached.
 
         Returns:
-            Optional[Token]: The next token that would be returned from a call to :meth:`Tokenizer.next`,
+            Token | None: The next token that would be returned from a call to :meth:`Tokenizer.next`,
             or :const:`None` if there are no more tokens.
 
         """
@@ -576,7 +576,7 @@ class Tokenizer:
         """Returns the next token in the stream.
 
         Returns:
-            Optional[Token]: The next token, or :const:`None` if there are no more tokens.
+            Token | None: The next token, or :const:`None` if there are no more tokens.
 
         """
         ret = self.peek()

--- a/graphtage/fibonacci.py
+++ b/graphtage/fibonacci.py
@@ -8,7 +8,8 @@ Fibonacci Heap that has amortized constant time insertion.
 
 """
 
-from typing import Callable, Generic, Iterator, Optional, TypeVar
+from collections.abc import Callable, Iterator
+from typing import Generic, TypeVar
 
 T = TypeVar('T')
 Key = TypeVar('Key')
@@ -31,9 +32,9 @@ class HeapNode(Generic[T, Key]):
             key = item
         self.key: Key = key
         """The key to be used when sorting this heap node."""
-        self.parent: Optional[HeapNode[T, Key]] = None
+        self.parent: HeapNode[T, Key] | None = None
         """The node's parent."""
-        self.child: Optional[HeapNode[T, Key]] = None
+        self.child: HeapNode[T, Key] | None = None
         """The node's child."""
         self.left: HeapNode[T, Key] = self
         """The left sibling of this node, or :obj:`self` if it has no left sibling."""
@@ -140,7 +141,7 @@ class HeapNode(Generic[T, Key]):
 
 class FibonacciHeap(Generic[T, Key]):
     """A Fibonacci Heap."""
-    def __init__(self, key: Optional[Callable[[T], Key]] = None):
+    def __init__(self, key: Callable[[T], Key] | None = None):
         """Initializes a Fibonacci heap.
 
         Args:
@@ -155,8 +156,8 @@ class FibonacciHeap(Generic[T, Key]):
             """The function to extract comparison keys from items."""
         else:
             self.key: Callable[[T], Key] = key
-        self._min: Optional[HeapNode[T, Key]] = None
-        self._root: Optional[HeapNode[T, Key]] = None
+        self._min: HeapNode[T, Key] | None = None
+        self._root: HeapNode[T, Key] | None = None
         self._n: int = 0
 
     def clear(self):
@@ -374,7 +375,7 @@ class ReversedComparator(Generic[Key]):
 
 class MaxFibonacciHeap(Generic[T, Key], FibonacciHeap[T, ReversedComparator[Key]]):
     """A Fibonacci Heap that yields items in decreasing order, using a :class:`ReversedComparator`."""
-    def __init__(self, key: Optional[Callable[[T], Key]] = None):
+    def __init__(self, key: Callable[[T], Key] | None = None):
         if key is None:
             def key(n: T):
                 return n

--- a/graphtage/fibonacci.py
+++ b/graphtage/fibonacci.py
@@ -46,9 +46,9 @@ class HeapNode(Generic[T, Key]):
         """The node's marked state."""
         self.deleted: bool = False
         """Whether the node has been deleted.
-        
+
         This is to prevent nodes from being manipulated after they have been removed from a heap.
-        
+
         Warning:
             Do not set :attr:`HeapNode.deleted` to :const:`True` unless the node has already been removed from the heap.
 
@@ -322,9 +322,8 @@ class FibonacciHeap(Generic[T, Key]):
                 d += 1
             a[d] = x
         for i in range(0, len(a)):
-            if a[i] is not None:
-                if a[i] <= self._min:
-                    self._min = a[i]
+            if a[i] is not None and a[i] <= self._min:
+                self._min = a[i]
 
     def _link(self, y: HeapNode[T, Key], x: HeapNode[T, Key]):
         self._remove_root(y)

--- a/graphtage/formatter.py
+++ b/graphtage/formatter.py
@@ -176,17 +176,8 @@ Examples:
 
 import inspect
 import logging
-import sys
 from abc import ABCMeta, abstractmethod
 from typing import Any, Callable, Generic, List, Optional, Sequence, Set, Type, TypeVar
-
-if sys.version_info.major == 3 and sys.version_info.minor < 7:
-    # Backward compatibility for pre-Python3.7
-    from typing import GenericMeta
-else:
-    # Create a dummy type for GenericMeta since it was removed in Python3.7
-    # It was a subclass of ABCMeta in Python3.6, anyway
-    GenericMeta = ABCMeta
 
 from .printer import Printer
 
@@ -198,7 +189,7 @@ FORMATTERS: Sequence['Formatter[Any]'] = []
 """A list of default instances of non-partial formatters that have subclassed :class:`Formatter`."""
 
 
-class FormatterChecker(GenericMeta):
+class FormatterChecker(ABCMeta):
     """The metaclass for :class:`Formatter`.
 
     For every class that subclasses :class:`Formatter`, if :attr:`Formatter.is_partial` is :const:`False` (the default)
@@ -364,14 +355,7 @@ class Formatter(Generic[T], metaclass=FormatterChecker):
         raise NotImplementedError()
 
 
-if sys.version_info.major == 3 and sys.version_info.minor < 7:
-    # Backward compatibility for pre-Python3.7
-    basic_formatter_types = (Formatter,)
-else:
-    basic_formatter_types = (Generic[T], Formatter[T])
-
-
-class BasicFormatter(*basic_formatter_types):
+class BasicFormatter(Generic[T], Formatter[T]):
     """A basic formatter that falls back on an item's natural string representation if no formatter is found."""
 
     def print(self, printer: Printer, item: T):

--- a/graphtage/formatter.py
+++ b/graphtage/formatter.py
@@ -134,7 +134,7 @@ Examples:
         ...         printer.newline()
         ...
         >>> class BarFormatter(BasicFormatter[Bar]):
-        ...     sub_format_types = [BarStringFormatter]
+        ...     sub_format_types = (BarStringFormatter,)
         ...     def print_Bar(self, printer: Printer, item: Bar):
         ...         printer.write("BarFormatter: ")
         ...         self.print(printer, item.bar)
@@ -228,9 +228,9 @@ class FormatterChecker(ABCMeta):
                             if a is not None and a != inspect.Signature.empty and inspect.isclass(a) \
                                     and not issubclass(Printer, a):
                                 raise TypeError(f"The type annotation for {name}.{member}(printer: {a}) was expected to be a superclass of graphtage.printer.Printer")
-                if not instance.is_partial and not cls.__name__ == 'BasicFormatter':
+                if not instance.is_partial and cls.__name__ != 'BasicFormatter':
                     FORMATTERS.append(instance)
-                setattr(cls, 'DEFAULT_INSTANCE', instance)
+                cls.DEFAULT_INSTANCE = instance
         super().__init__(name, bases, clsdict)
 
 
@@ -253,7 +253,7 @@ def _get_formatter(
                         return getattr(sub_formatter, f'print_{c.__name__}')
                     grandchildren.extend(sub_formatter.sub_formatters)
         tested.add(base_formatter.__class__)
-        tested |= set(s.__class__ for s in base_formatter.sub_formatters)
+        tested |= {s.__class__ for s in base_formatter.sub_formatters}
         for grandchild in grandchildren:
             ret = _get_formatter(node_type, grandchild, tested)
             if ret is not None:
@@ -298,15 +298,17 @@ class Formatter(Generic[T], metaclass=FormatterChecker):
     """A default instance of this formatter, automatically instantiated by the :class:`FormatterChecker` metaclass."""
     sub_format_types: Sequence[type['Formatter[T]']] = ()
     """A list of formatter types that should be used as sub-formatters in the :ref:`Formatting Protocol`."""
-    sub_formatters: list['Formatter[T]'] = []
+    # Not a ClassVar: Formatter.__new__ gives every instance its own list. The class-level empty
+    # list is only a default for classes that are never instantiated.
+    sub_formatters: list['Formatter[T]'] = []  # noqa: RUF012
     """The list of instantiated formatters corresponding to :attr:`Formatter.sub_format_types`.
-    
+
     This list is automatically populated by :meth:`Formatter.__new__` and should never be manually modified.
-    
+
     """
     parent: Optional['Formatter[T]'] = None
     """The parent formatter for this formatter instance.
-    
+
     This is automatically populated by :meth:`Formatter.__new__` and should never be manually modified.
 
     """
@@ -328,7 +330,7 @@ class Formatter(Generic[T], metaclass=FormatterChecker):
 
         """
         ret: Formatter[T] = super().__new__(cls)
-        setattr(ret, 'sub_formatters', [])
+        ret.sub_formatters = []
         for sub_formatter in ret.sub_format_types:
             ret.sub_formatters.append(sub_formatter())
             ret.sub_formatters[-1].parent = ret

--- a/graphtage/formatter.py
+++ b/graphtage/formatter.py
@@ -177,10 +177,10 @@ Examples:
 import inspect
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, Generic, List, Optional, Sequence, Set, Type, TypeVar
+from collections.abc import Callable, Sequence
+from typing import Any, Generic, Optional, TypeVar
 
 from .printer import Printer
-
 
 log = logging.getLogger(__name__)
 
@@ -238,10 +238,10 @@ T = TypeVar('T')
 
 
 def _get_formatter(
-        node_type: Type[T],
+        node_type: type[T],
         base_formatter: 'Formatter',
-        tested: Set[Type['Formatter']]
-) -> Optional[Callable[[Printer, T], Any]]:
+        tested: set[type['Formatter']]
+) -> Callable[[Printer, T], Any] | None:
     if base_formatter.__class__ not in tested:
         grandchildren = []
         for c in node_type.mro():
@@ -263,9 +263,9 @@ def _get_formatter(
 
 
 def get_formatter(
-        node_type: Type[T],
+        node_type: type[T],
         base_formatter: Optional['Formatter'] = None
-) -> Optional[Callable[[Printer, T], Any]]:
+) -> Callable[[Printer, T], Any] | None:
     """Uses the :ref:`Formatting Protocol` to determine the correct formatter for a given type.
 
     See :ref:`this section <What the formatter module can do>` for a number of examples.
@@ -278,7 +278,7 @@ def get_formatter(
     Returns: The formatter for object type :obj:`node_type`, or :const:`None` if none was found.
 
     """
-    tested_formatters: Set[Type[Formatter]] = set()
+    tested_formatters: set[type[Formatter]] = set()
     if base_formatter is not None:
         ret = _get_formatter(node_type, base_formatter, tested_formatters)
         if ret is not None:
@@ -296,9 +296,9 @@ class Formatter(Generic[T], metaclass=FormatterChecker):
 
     DEFAULT_INSTANCE: 'Formatter[T]' = None
     """A default instance of this formatter, automatically instantiated by the :class:`FormatterChecker` metaclass."""
-    sub_format_types: Sequence[Type['Formatter[T]']] = ()
+    sub_format_types: Sequence[type['Formatter[T]']] = ()
     """A list of formatter types that should be used as sub-formatters in the :ref:`Formatting Protocol`."""
-    sub_formatters: List['Formatter[T]'] = []
+    sub_formatters: list['Formatter[T]'] = []
     """The list of instantiated formatters corresponding to :attr:`Formatter.sub_format_types`.
     
     This list is automatically populated by :meth:`Formatter.__new__` and should never be manually modified.
@@ -334,7 +334,7 @@ class Formatter(Generic[T], metaclass=FormatterChecker):
             ret.sub_formatters[-1].parent = ret
         return ret
 
-    def get_formatter(self, item: T) -> Optional[Callable[[Printer, T], Any]]:
+    def get_formatter(self, item: T) -> Callable[[Printer, T], Any] | None:
         """Looks up a formatter for the given item using this formatter as a base.
 
         Equivalent to::

--- a/graphtage/git.py
+++ b/graphtage/git.py
@@ -19,7 +19,7 @@ See the "Git Integration" section of the Graphtage README for the ``git`` config
 
 import os
 import sys
-from typing import List, Optional, Sequence, Tuple
+from collections.abc import Sequence
 
 from . import graphtage
 from .__main__ import EXIT_DIFFERENCES_FOUND, EXIT_ERROR, EXIT_SUCCESS, register_mimetypes
@@ -42,7 +42,7 @@ section of the Graphtage README.
 """
 
 
-def split_options(argv: Sequence[str]) -> Tuple[List[str], List[str]]:
+def split_options(argv: Sequence[str]) -> tuple[list[str], list[str]]:
     """Splits the leading Graphtage options off of the arguments that git supplies.
 
     Git appends its own positional arguments after whatever command the user configured, so every argument up to
@@ -62,7 +62,7 @@ def split_options(argv: Sequence[str]) -> Tuple[List[str], List[str]]:
     return list(argv[:index]), list(argv[index:])
 
 
-def mime_options(path: str, forwarded: Sequence[str]) -> List[str]:
+def mime_options(path: str, forwarded: Sequence[str]) -> list[str]:
     """Builds the Graphtage MIME type options implied by a path in the repository.
 
     Args:
@@ -85,7 +85,7 @@ def mime_options(path: str, forwarded: Sequence[str]) -> List[str]:
     return [f'{prefix}mime={mime_type}' for prefix in prefixes]
 
 
-def absent_revision(from_path: str, to_path: str) -> Optional[str]:
+def absent_revision(from_path: str, to_path: str) -> str | None:
     """Describes a change that leaves Graphtage with only one revision to work from.
 
     Args:
@@ -103,7 +103,7 @@ def absent_revision(from_path: str, to_path: str) -> Optional[str]:
     return None
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     """Runs Graphtage over the two revisions that git supplies.
 
     Args:

--- a/graphtage/git.py
+++ b/graphtage/git.py
@@ -93,7 +93,7 @@ def absent_revision(from_path: str, to_path: str) -> str | None:
         to_path: The new revision, which git passes as its fifth argument.
 
     Returns:
-        Optional[str]: ``'added'`` or ``'deleted'`` if one of the revisions is missing, and :const:`None` if both
+        str | None: ``'added'`` or ``'deleted'`` if one of the revisions is missing, and :const:`None` if both
         of them exist.
     """
     if from_path in ABSENT_FILE_NAMES:

--- a/graphtage/graphtage.py
+++ b/graphtage/graphtage.py
@@ -1,20 +1,19 @@
 __docformat__ = "google"
 
+import copy as copy_module
 import mimetypes
 from abc import ABC, ABCMeta, abstractmethod
-import copy as copy_module
-from typing import Any, Collection, Dict, Generic, Iterable, Iterator, List, Optional, Tuple, Type, TypeVar, Union
+from collections.abc import Collection, Iterable, Iterator
+from typing import Any, Generic, TypeVar
 
 from .bounds import Range
-from .edits import AbstractEdit, EditCollection
-from .edits import Insert, Match, Remove, Replace, AbstractCompoundEdit
+from .edits import AbstractCompoundEdit, AbstractEdit, EditCollection, Insert, Match, Remove, Replace
 from .levenshtein import EditDistance, levenshtein_distance
 from .multiset import MultiSetEdit
-from .printer import Back, Fore, NullANSIContext, NULL_PRINTER, Printer
+from .printer import NULL_PRINTER, Back, Fore, NullANSIContext, Printer
 from .sequences import FixedLengthSequenceEdit, SequenceEdit, SequenceNode
 from .tree import ContainerNode, Edit, GraphtageFormatter, TreeNode
 from .utils import HashableCounter
-
 
 C = TypeVar("C", bound=TreeNode)
 T = TypeVar("T", bound=TreeNode)
@@ -207,13 +206,13 @@ class KeyValuePairNode(ContainerNode):
         with printer.color(Fore.BLUE):
             printer.write("]")
 
-    def editable_dict(self) -> Dict[str, Any]:
+    def editable_dict(self) -> dict[str, Any]:
         ret = dict(self.__dict__)
         ret["key"] = self.key.make_edited()
         ret["value"] = self.value.make_edited()
         return ret
 
-    def children(self) -> Tuple[LeafNode, TreeNode]:
+    def children(self) -> tuple[LeafNode, TreeNode]:
         return self.key, self.value
 
     def edits(self, node: TreeNode) -> Edit:
@@ -297,7 +296,7 @@ class KeyValuePairNode(ContainerNode):
         return f"{self.key!s}: {self.value!s}"
 
 
-class ListNode(SequenceNode[Tuple[T, ...]], Generic[T]):
+class ListNode(SequenceNode[tuple[T, ...]], Generic[T]):
     """A node containing an ordered sequence of nodes."""
 
     def __init__(
@@ -324,7 +323,7 @@ class ListNode(SequenceNode[Tuple[T, ...]], Generic[T]):
         return [n.to_obj() for n in self]
 
     @property
-    def container_type(self) -> Type[Tuple[T, ...]]:
+    def container_type(self) -> type[tuple[T, ...]]:
         """The container type required by :class:`graphtage.sequences.SequenceNode`
 
         Returns:
@@ -376,7 +375,7 @@ class MultiSetNode(SequenceNode[HashableCounter[T]], Generic[T]):
         return HashableCounter(n.to_obj() for n in self)
 
     @property
-    def container_type(self) -> Type[HashableCounter[T]]:
+    def container_type(self) -> type[HashableCounter[T]]:
         return HashableCounter
 
     def edits(self, node: TreeNode) -> Edit:
@@ -439,7 +438,7 @@ class MappingNode(ContainerNode, ABC):
 
     @classmethod
     @abstractmethod
-    def from_dict(cls: Type[T], source_dict: Dict[LeafNode, TreeNode]) -> T:
+    def from_dict(cls: type[T], source_dict: dict[LeafNode, TreeNode]) -> T:
         """Constructs a :class:`MappingNode` from a mapping of :class:`LeafNode` to :class:`TreeNode`.
 
         Args:
@@ -451,7 +450,7 @@ class MappingNode(ContainerNode, ABC):
         """
         raise NotImplementedError()
 
-    def to_obj(self) -> Dict[Any, Any]:
+    def to_obj(self) -> dict[Any, Any]:
         return {
             k.to_obj(): v.to_obj() for k, v in self.items()
         }
@@ -460,7 +459,7 @@ class MappingNode(ContainerNode, ABC):
         # this is handled by KeyValuePairNode
         pass
 
-    def items(self) -> Iterator[Tuple[TreeNode, TreeNode]]:
+    def items(self) -> Iterator[tuple[TreeNode, TreeNode]]:
         """Iterates over the key/value pairs in this mapping, similar to :meth:`dict.items`.
 
         The implementation is equivalent to::
@@ -536,7 +535,7 @@ class DictNode(MappingNode, MultiSetNode[KeyValuePairNode]):
     """
 
     @classmethod
-    def from_dict(cls: Type[T], source_dict: Dict[LeafNode, TreeNode]) -> T:
+    def from_dict(cls: type[T], source_dict: dict[LeafNode, TreeNode]) -> T:
         """Constructs a :class:`DictNode` from a mapping of :class:`LeafNode` to :class:`TreeNode`.
 
         Args:
@@ -560,7 +559,7 @@ class DictNode(MappingNode, MultiSetNode[KeyValuePairNode]):
         yield from self._children.elements()
 
 
-class FixedKeyDictNodeEdit(SequenceEdit, EditCollection[List]):
+class FixedKeyDictNodeEdit(SequenceEdit, EditCollection[list]):
     """The edit type returned by :class:`FixedKeyDictNode`."""
 
     __slots__ = ()
@@ -581,7 +580,7 @@ class FixedKeyDictNodeEdit(SequenceEdit, EditCollection[List]):
         )
 
 
-class FixedKeyDictNode(MappingNode, SequenceNode[Dict[LeafNode, KeyValuePairNode]]):
+class FixedKeyDictNode(MappingNode, SequenceNode[dict[LeafNode, KeyValuePairNode]]):
     """A dictionary that only attempts to match two :class:`KeyValuePairNode` objects if they share the same key.
 
     This is the most efficient dictionary matching node type, and is what is used with the
@@ -591,7 +590,7 @@ class FixedKeyDictNode(MappingNode, SequenceNode[Dict[LeafNode, KeyValuePairNode
         This implementation does not currently support duplicate keys.
     """
     @property
-    def container_type(self) -> Type[Dict[LeafNode, KeyValuePairNode]]:
+    def container_type(self) -> type[dict[LeafNode, KeyValuePairNode]]:
         """The container type required by :class:`graphtage.sequences.SequenceNode`
 
         Returns:
@@ -601,7 +600,7 @@ class FixedKeyDictNode(MappingNode, SequenceNode[Dict[LeafNode, KeyValuePairNode
         return dict
 
     @classmethod
-    def from_dict(cls: Type[T], source_dict: Dict[LeafNode, TreeNode]) -> T:
+    def from_dict(cls: type[T], source_dict: dict[LeafNode, TreeNode]) -> T:
         """Constructs a :class:`FixedKeyDictNode` from a mapping of :class:`LeafNode` to :class:`TreeNode`.
 
         Args:
@@ -657,10 +656,10 @@ class FixedKeyDictNode(MappingNode, SequenceNode[Dict[LeafNode, KeyValuePairNode
         else:
             return Replace(self, node)
 
-    def items(self) -> Iterator[Tuple[LeafNode, TreeNode]]:
+    def items(self) -> Iterator[tuple[LeafNode, TreeNode]]:
         yield from iter(self._children.items())
 
-    def editable_dict(self) -> Dict[str, Any]:
+    def editable_dict(self) -> dict[str, Any]:
         ret = dict(self.__dict__)
         ret["_children"] = {e.key: e for e in (kvp.make_edited() for kvp in self)}
         return ret
@@ -748,7 +747,7 @@ class StringFormatter(GraphtageFormatter):
             return c
 
     def write_char(
-            self, printer: Printer, c: Union[str, int], index: int, num_edits: int, removed=False, inserted=False
+            self, printer: Printer, c: str | int, index: int, num_edits: int, removed=False, inserted=False
     ):
         """Writes a character to the printer.
 
@@ -890,7 +889,7 @@ class StringFormatter(GraphtageFormatter):
 class StringNode(LeafNode):
     """A node containing a string"""
 
-    def __init__(self, string_like: Union[str, bytes], quoted=True):
+    def __init__(self, string_like: str | bytes, quoted=True):
         """Initializes a string node.
 
         Args:
@@ -992,8 +991,8 @@ def string_edit_distance(s1: str, s2: str) -> EditDistance:
     return EditDistance(list1, list2, list1.children(), list2.children(), insert_remove_penalty=0)
 
 
-FILETYPES_BY_MIME: Dict[str, 'Filetype'] = {}
-FILETYPES_BY_TYPENAME: Dict[str, 'Filetype'] = {}
+FILETYPES_BY_MIME: dict[str, 'Filetype'] = {}
+FILETYPES_BY_TYPENAME: dict[str, 'Filetype'] = {}
 
 
 class FiletypeWatcher(ABCMeta):
@@ -1105,7 +1104,7 @@ class Filetype(metaclass=FiletypeWatcher):
         """
         self.name = type_name
         self.default_mimetype: str = default_mimetype
-        self.mimetypes: Tuple[str, ...] = (default_mimetype,) + tuple(mimetypes)
+        self.mimetypes: tuple[str, ...] = (default_mimetype,) + tuple(mimetypes)
         for mime_type in self.mimetypes:
             if mime_type in FILETYPES_BY_MIME:
                 raise ValueError(f"MIME type {mime_type} is already assigned to {FILETYPES_BY_MIME[mime_type]}")
@@ -1117,7 +1116,7 @@ class Filetype(metaclass=FiletypeWatcher):
         FILETYPES_BY_TYPENAME[self.name] = self
 
     @abstractmethod
-    def build_tree(self, path: str, options: Optional[BuildOptions] = None) -> TreeNode:
+    def build_tree(self, path: str, options: BuildOptions | None = None) -> TreeNode:
         """Builds an intermediate representation tree from a file of this :class:`Filetype`.
 
         Args:
@@ -1131,7 +1130,7 @@ class Filetype(metaclass=FiletypeWatcher):
         raise NotImplementedError()
 
     @abstractmethod
-    def build_tree_handling_errors(self, path: str, options: Optional[BuildOptions] = None) -> Union[str, TreeNode]:
+    def build_tree_handling_errors(self, path: str, options: BuildOptions | None = None) -> str | TreeNode:
         """Same as :meth:`Filetype.build_tree`, but it should return a human-readable error string on failure.
 
         This function should never throw an exception.
@@ -1152,7 +1151,7 @@ class Filetype(metaclass=FiletypeWatcher):
         raise NotImplementedError()
 
 
-def get_filetype(path: Optional[str] = None, mime_type: Optional[str] = None) -> Filetype:
+def get_filetype(path: str | None = None, mime_type: str | None = None) -> Filetype:
     """Looks up the filetype for the given path.
 
     At least one of :obj:`path` or :obj:`mime_type` must be not :const:`None`. If both are provided, only

--- a/graphtage/graphtage.py
+++ b/graphtage/graphtage.py
@@ -848,17 +848,15 @@ class StringFormatter(GraphtageFormatter):
                     remove_seq.append(to_remove)
                     add_seq.append(to_add)
                 else:
-                    with printer.color(Fore.WHITE).background(Back.RED).bright():
-                        with printer.strike():
-                            for rm in remove_seq:
-                                self.write_char(p, rm, index, num_edits, removed=True)
-                                index += 1
+                    with printer.color(Fore.WHITE).background(Back.RED).bright(), printer.strike():
+                        for rm in remove_seq:
+                            self.write_char(p, rm, index, num_edits, removed=True)
+                            index += 1
                     remove_seq = []
-                    with printer.color(Fore.WHITE).background(Back.GREEN).bright():
-                        with printer.under_plus():
-                            for add in add_seq:
-                                self.write_char(p, add, index, num_edits, inserted=True)
-                                index += 1
+                    with printer.color(Fore.WHITE).background(Back.GREEN).bright(), printer.under_plus():
+                        for add in add_seq:
+                            self.write_char(p, add, index, num_edits, inserted=True)
+                            index += 1
                     add_seq = []
                     if to_remove is not None:
                         remove_seq.append(to_remove)
@@ -867,16 +865,14 @@ class StringFormatter(GraphtageFormatter):
                     if matched is not None:
                         self.write_char(p, matched, index, num_edits)
                         index += 1
-            with printer.color(Fore.WHITE).background(Back.RED).bright():
-                with printer.strike():
-                    for j, rm in enumerate(remove_seq):
-                        self.write_char(p, rm, index, num_edits, removed=True)
-                        index += 1
-            with printer.color(Fore.WHITE).background(Back.GREEN).bright():
-                with printer.under_plus():
-                    for add in add_seq:
-                        self.write_char(p, add, index, num_edits, inserted=True)
-                        index += 1
+            with printer.color(Fore.WHITE).background(Back.RED).bright(), printer.strike():
+                for rm in remove_seq:
+                    self.write_char(p, rm, index, num_edits, removed=True)
+                    index += 1
+            with printer.color(Fore.WHITE).background(Back.GREEN).bright(), printer.under_plus():
+                for add in add_seq:
+                    self.write_char(p, add, index, num_edits, inserted=True)
+                    index += 1
             if self._last_was_inserted:
                 printer.write(Insert.INSERT_STRING)
                 self._last_was_inserted = False
@@ -954,10 +950,7 @@ class NullNode(LeafNode):
             return Replace(self, node)
 
     def __lt__(self, other):
-        if isinstance(other, NullNode):
-            return False
-        else:
-            return True
+        return not isinstance(other, NullNode)
 
     def __eq__(self, other):
         return isinstance(other, NullNode)
@@ -1008,7 +1001,7 @@ class FiletypeWatcher(ABCMeta):
             instance = cls()
             assert instance.name in FILETYPES_BY_TYPENAME
             assert instance.default_mimetype in FILETYPES_BY_MIME
-            setattr(cls, "default_instance", instance)
+            cls.default_instance = instance
         super().__init__(name, bases, clsdict)
 
 
@@ -1057,10 +1050,10 @@ class BuildOptions:
         """Whether to automatically match key/value pairs in dictionaries if they share the same key"""
         self.check_for_cycles = check_for_cyces
         """If possible, check for cycles in the input
-        
+
         If `True` and if `ignore_cycles` is `False`, then a :class:`ValueError` will be raised if a cycle is detected
         while constructing the Graphtage tree.
-        
+
         """
         self.ignore_cycles = ignore_cycles
         """If `True` and if `check_for_cycles` is also `True`, then ignore cycles in the input,
@@ -1104,7 +1097,7 @@ class Filetype(metaclass=FiletypeWatcher):
         """
         self.name = type_name
         self.default_mimetype: str = default_mimetype
-        self.mimetypes: tuple[str, ...] = (default_mimetype,) + tuple(mimetypes)
+        self.mimetypes: tuple[str, ...] = (default_mimetype, *mimetypes)
         for mime_type in self.mimetypes:
             if mime_type in FILETYPES_BY_MIME:
                 raise ValueError(f"MIME type {mime_type} is already assigned to {FILETYPES_BY_MIME[mime_type]}")

--- a/graphtage/graphtage.py
+++ b/graphtage/graphtage.py
@@ -1133,7 +1133,7 @@ class Filetype(metaclass=FiletypeWatcher):
             options: An optional set of options for building the tree
 
         Returns:
-            Union[str, TreeNode]: On success, the root tree node, or a string containing the error message on failure.
+            str | TreeNode: On success, the root tree node, or a string containing the error message on failure.
 
         """
         raise NotImplementedError()

--- a/graphtage/ini.py
+++ b/graphtage/ini.py
@@ -110,7 +110,7 @@ class INIListFormatter(SequenceFormatter):
 class INIMappingFormatter(SequenceFormatter):
     """A formatter for an INI document and for each of its section bodies."""
     is_partial = True
-    sub_format_types = [INIOptionFormatter]
+    sub_format_types = (INIOptionFormatter,)
 
     def __init__(self):
         super().__init__("", "", "")
@@ -134,7 +134,7 @@ class INIMappingFormatter(SequenceFormatter):
 
 class INIFormatter(GraphtageFormatter):
     """A formatter for INI files."""
-    sub_format_types = [INIMappingFormatter, INIListFormatter, INIStringFormatter]
+    sub_format_types = (INIMappingFormatter, INIListFormatter, INIStringFormatter)
 
     def print(self, printer: Printer, *args, **kwargs):
         if args and isinstance(args[0], TreeNode) and args[0].parent is None:

--- a/graphtage/ini.py
+++ b/graphtage/ini.py
@@ -13,7 +13,6 @@ file that :mod:`configparser` can read back.
 
 import configparser
 import os
-from typing import Optional, Union
 
 from . import json
 from .graphtage import BuildOptions, Filetype, KeyValuePairNode, MappingNode, StringFormatter, StringNode
@@ -36,7 +35,7 @@ def _parser() -> configparser.ConfigParser:
     return parser
 
 
-def build_tree(path: str, options: Optional[BuildOptions] = None) -> TreeNode:
+def build_tree(path: str, options: BuildOptions | None = None) -> TreeNode:
     parser = _parser()
     with open(path, encoding="utf-8") as f:
         parser.read_file(f)
@@ -44,7 +43,7 @@ def build_tree(path: str, options: Optional[BuildOptions] = None) -> TreeNode:
     return json.build_tree(data, options)
 
 
-def _unquote(node: Optional[TreeNode]):
+def _unquote(node: TreeNode | None):
     """Clears a string node's quoting, since INI has no string delimiters."""
     if isinstance(node, StringNode):
         node.quoted = False
@@ -162,11 +161,11 @@ class INI(Filetype):
             "text/x-ini",
         )
 
-    def build_tree(self, path: str, options: Optional[BuildOptions] = None) -> TreeNode:
+    def build_tree(self, path: str, options: BuildOptions | None = None) -> TreeNode:
         """Equivalent to :func:`build_tree`"""
         return build_tree(path, options=options)
 
-    def build_tree_handling_errors(self, path: str, options: Optional[BuildOptions] = None) -> Union[str, TreeNode]:
+    def build_tree_handling_errors(self, path: str, options: BuildOptions | None = None) -> str | TreeNode:
         try:
             return self.build_tree(path=path, options=options)
         except (configparser.Error, OSError, ValueError) as e:

--- a/graphtage/json.py
+++ b/graphtage/json.py
@@ -296,7 +296,7 @@ class JSON5(Filetype):
         try:
             return self.build_tree(path=path, options=options)
         except ValueError as ve:
-            return f'Error parsing {os.path.basename(path)}: {ve:!s}'
+            return f'Error parsing {os.path.basename(path)}: {ve!s}'
 
     def get_default_formatter(self) -> JSONFormatter:
         return JSONFormatter.DEFAULT_INSTANCE

--- a/graphtage/json.py
+++ b/graphtage/json.py
@@ -6,21 +6,34 @@
 """
 
 import json
-import json5
 import os
-from typing import Optional, Union
 
-from .graphtage import BoolNode, BuildOptions, DictNode, Filetype, FixedKeyDictNode, \
-    FloatNode, IntegerNode, KeyValuePairNode, LeafNode, ListNode, NullNode, StringFormatter, StringNode, \
-    UnorderedListNode
-from .printer import Fore, get_default_printer, Printer
+import json5
+
+from .graphtage import (
+    BoolNode,
+    BuildOptions,
+    DictNode,
+    Filetype,
+    FixedKeyDictNode,
+    FloatNode,
+    IntegerNode,
+    KeyValuePairNode,
+    LeafNode,
+    ListNode,
+    NullNode,
+    StringFormatter,
+    StringNode,
+    UnorderedListNode,
+)
+from .printer import Fore, Printer, get_default_printer
 from .sequences import SequenceFormatter
 from .tree import ContainerNode, GraphtageFormatter, TreeNode
 
 
 def build_tree(
-        python_obj: Union[int, float, bool, str, bytes, list, dict],
-        options: Optional[BuildOptions] = None,
+        python_obj: int | float | bool | str | bytes | list | dict,
+        options: BuildOptions | None = None,
         force_leaf_node: bool = False) -> TreeNode:
     """Builds a Graphtage tree from an arbitrary Python object.
 
@@ -237,7 +250,7 @@ class JSONFormatter(GraphtageFormatter):
 
         """
         # Treat the container like a list
-        list_node = ListNode((c.copy() for c in node.children()))
+        list_node = ListNode(c.copy() for c in node.children())
         self.print(printer, list_node)
 
 
@@ -259,11 +272,11 @@ class JSON(Filetype):
             'text/x-json'
         )
 
-    def build_tree(self, path: str, options: Optional[BuildOptions] = None) -> TreeNode:
+    def build_tree(self, path: str, options: BuildOptions | None = None) -> TreeNode:
         with open(path) as f:
             return build_tree(json.load(f), options)
 
-    def build_tree_handling_errors(self, path: str, options: Optional[BuildOptions] = None) -> Union[str, TreeNode]:
+    def build_tree_handling_errors(self, path: str, options: BuildOptions | None = None) -> str | TreeNode:
         try:
             return self.build_tree(path=path, options=options)
         except json.decoder.JSONDecodeError as de:
@@ -288,11 +301,11 @@ class JSON5(Filetype):
             'text/x-json5'
         )
 
-    def build_tree(self, path: str, options: Optional[BuildOptions] = None) -> TreeNode:
+    def build_tree(self, path: str, options: BuildOptions | None = None) -> TreeNode:
         with open(path) as f:
             return build_tree(json5.load(f), options)
 
-    def build_tree_handling_errors(self, path: str, options: Optional[BuildOptions] = None) -> Union[str, TreeNode]:
+    def build_tree_handling_errors(self, path: str, options: BuildOptions | None = None) -> str | TreeNode:
         try:
             return self.build_tree(path=path, options=options)
         except ValueError as ve:

--- a/graphtage/json.py
+++ b/graphtage/json.py
@@ -65,7 +65,7 @@ def build_tree(
         return StringNode(python_obj.decode('utf-8'))
     elif force_leaf_node:
         raise ValueError(f"{python_obj!r} was expected to be an int or string, but was instead a {type(python_obj)}")
-    elif isinstance(python_obj, list) or isinstance(python_obj, tuple):
+    elif isinstance(python_obj, (list, tuple)):
         children = [
             build_tree(n, options=options) for n in
             get_default_printer().tqdm(python_obj, delay=2.0, desc="Loading JSON List", leave=False)
@@ -219,7 +219,7 @@ class JSONStringFormatter(StringFormatter):
 
 class JSONFormatter(GraphtageFormatter):
     """The default JSON formatter."""
-    sub_format_types = [JSONStringFormatter, JSONListFormatter, JSONDictFormatter]
+    sub_format_types = (JSONStringFormatter, JSONListFormatter, JSONDictFormatter)
 
     def print_LeafNode(self, printer: Printer, node: LeafNode):
         """Prints a :class:`graphtage.LeafNode`.

--- a/graphtage/levenshtein.py
+++ b/graphtage/levenshtein.py
@@ -16,7 +16,7 @@ optimal edit sequence is discovered.
 
 import itertools
 import logging
-from typing import Iterator, List, Optional, Sequence, Tuple
+from collections.abc import Iterator, Sequence
 
 import numpy as np
 
@@ -26,7 +26,6 @@ from .fibonacci import FibonacciHeap
 from .printer import get_default_printer
 from .sequences import SequenceEdit
 from .tree import Edit, TreeNode
-
 
 log = logging.getLogger(__name__)
 
@@ -44,7 +43,7 @@ def levenshtein_distance(s: str, t: str) -> int:
     """
     rows = len(s) + 1
     cols = len(t) + 1
-    dist: List[List[int]] = [[0] * cols for _ in range(rows)]
+    dist: list[list[int]] = [[0] * cols for _ in range(rows)]
 
     for i in range(1, rows):
         dist[i][0] = i
@@ -110,13 +109,13 @@ class EditDistance(SequenceEdit):
         self.penalty: int = insert_remove_penalty
         # Optimization: See if the sequences trivially share a common prefix or suffix.
         # If so, this will quadratically reduce the size of the Levenshtein matrix
-        self.shared_prefix: List[Tuple[TreeNode, TreeNode]] = []
+        self.shared_prefix: list[tuple[TreeNode, TreeNode]] = []
         for fn, tn in zip(from_seq, to_seq):
             if fn == tn:
                 self.shared_prefix.append((fn, tn))
             else:
                 break
-        self.reversed_shared_suffix: List[Tuple[TreeNode, TreeNode]] = []
+        self.reversed_shared_suffix: list[tuple[TreeNode, TreeNode]] = []
         for fn, tn in zip(
                 reversed(from_seq[len(self.shared_prefix):]),
                 reversed(to_seq[len(self.shared_prefix):])
@@ -148,21 +147,21 @@ class EditDistance(SequenceEdit):
             sum(node.total_size + self.penalty for node in from_seq) +
             sum(node.total_size + self.penalty for node in to_seq)
         )
-        self.edit_matrix: List[List[Optional[Edit]]] = [
+        self.edit_matrix: list[list[Edit | None]] = [
             [None] * (len(self.from_seq) + 1) for _ in range(len(self.to_seq) + 1)
         ]
         self.path_costs = np.full((len(self.to_seq) + 1, len(self.from_seq) + 1), 0, dtype=np.uint16)
         self.costs = np.full((len(self.to_seq) + 1, len(self.from_seq) + 1), 0, dtype=np.uint64)
         self._fringe_row: int = -1
         self._fringe_col: int = 0
-        self._last_fringe: List[Tuple[int, int]] = []
+        self._last_fringe: list[tuple[int, int]] = []
         super().__init__(
             from_node=from_node,
             to_node=to_node,
             constant_cost=constant_cost,
             cost_upper_bound=cost_upper_bound
         )
-        self.__edits: Optional[List[Edit]] = None
+        self.__edits: list[Edit] | None = None
 
     def _add_node(self, row: int, col: int) -> bool:
         if self.edit_matrix[row][col] is not None or col > len(self.from_seq) or row > len(self.to_seq):
@@ -182,7 +181,7 @@ class EditDistance(SequenceEdit):
         self.edit_matrix[row][col] = edit
         return True
 
-    def _fringe_diagonal(self) -> Iterator[Tuple[int, int]]:
+    def _fringe_diagonal(self) -> Iterator[tuple[int, int]]:
         row, col = self._fringe_row, self._fringe_col
         while row >= 0 and col <= len(self.from_seq):
             yield row, col
@@ -232,7 +231,7 @@ class EditDistance(SequenceEdit):
             raise ValueError(f"Could not tighten {edit!r} to a definitive bound; got {bounds!r}")
         return bounds.upper_bound
 
-    def _best_match(self, row: int, col: int) -> Tuple[int, int, Edit]:
+    def _best_match(self, row: int, col: int) -> tuple[int, int, Edit]:
         """Selects the predecessor cell that reaches this cell of the Levenshtein matrix most cheaply.
 
         Each candidate is scored by the accumulated cost of its predecessor plus the cost of the edit that
@@ -259,8 +258,8 @@ class EditDistance(SequenceEdit):
         elif col == 0:
             assert row > 0
             return row - 1, col, self.edit_matrix[row][0]
-        best_key: Optional[Tuple[int, int]] = None
-        best: Optional[Tuple[int, int, Edit]] = None
+        best_key: tuple[int, int] | None = None
+        best: tuple[int, int, Edit] | None = None
         for prev_row, prev_col, edit in (
                 (row - 1, col - 1, self.edit_matrix[row][col]),
                 (row - 1, col, self.edit_matrix[row][0]),
@@ -391,7 +390,7 @@ class EditDistance(SequenceEdit):
 
     def edits(self) -> Iterator[Edit]:
         if self.__edits is None:
-            reversed_suffix: List[Edit] = [
+            reversed_suffix: list[Edit] = [
                 Match(from_node, to_node, 0) for from_node, to_node in self.reversed_shared_suffix
             ]
             if self.to_seq or self.from_seq:

--- a/graphtage/levenshtein.py
+++ b/graphtage/levenshtein.py
@@ -83,9 +83,18 @@ class EditDistance(SequenceEdit):
     """
 
     __slots__ = (
-        'penalty', 'shared_prefix', 'reversed_shared_suffix', 'from_seq', 'to_seq',
-        'edit_matrix', 'path_costs', 'costs', '_fringe_row', '_fringe_col',
-        '_last_fringe', '_EditDistance__edits'
+        '_EditDistance__edits',
+        '_fringe_col',
+        '_fringe_row',
+        '_last_fringe',
+        'costs',
+        'edit_matrix',
+        'from_seq',
+        'path_costs',
+        'penalty',
+        'reversed_shared_suffix',
+        'shared_prefix',
+        'to_seq'
     )
 
     def __init__(
@@ -110,7 +119,7 @@ class EditDistance(SequenceEdit):
         # Optimization: See if the sequences trivially share a common prefix or suffix.
         # If so, this will quadratically reduce the size of the Levenshtein matrix
         self.shared_prefix: list[tuple[TreeNode, TreeNode]] = []
-        for fn, tn in zip(from_seq, to_seq):
+        for fn, tn in zip(from_seq, to_seq, strict=False):
             if fn == tn:
                 self.shared_prefix.append((fn, tn))
             else:
@@ -118,7 +127,8 @@ class EditDistance(SequenceEdit):
         self.reversed_shared_suffix: list[tuple[TreeNode, TreeNode]] = []
         for fn, tn in zip(
                 reversed(from_seq[len(self.shared_prefix):]),
-                reversed(to_seq[len(self.shared_prefix):])
+                reversed(to_seq[len(self.shared_prefix):]),
+                strict=False
         ):
             if fn == tn:
                 self.reversed_shared_suffix.append((fn, tn))
@@ -199,12 +209,9 @@ class EditDistance(SequenceEdit):
         for row, col in self._fringe_diagonal():
             self._add_node(row, col)
         if self._fringe_col >= len(self.from_seq):
-            if self._fringe_row < len(self.to_seq):
-                # This is an edge case when the string we are matching from is shorter than the one we are matching to
-                return True
-            return False
-        else:
-            return True
+            # This is an edge case when the string we are matching from is shorter than the one we are matching to
+            return self._fringe_row < len(self.to_seq)
+        return True
 
     def is_complete(self) -> bool:
         """An edit distance edit is only complete once its Levenshtein edit matrix has been fully constructed."""

--- a/graphtage/matching.py
+++ b/graphtage/matching.py
@@ -104,23 +104,22 @@ class MatchingNode(Generic[T], metaclass=ABCMeta):
     def construct_edges(self) -> dict['MatchingNode[T]', Edge[T]]:
         pass
 
-    def edges(self) -> Iterable[Edge[T]]:
+    def _edge_map(self) -> dict['MatchingNode[T]', Edge[T]]:
         if self._edges is None:
             self._edges = self.construct_edges()
-        return self._edges.values()
+        return self._edges
+
+    def edges(self) -> Iterable[Edge[T]]:
+        return self._edge_map().values()
 
     def __repr__(self):
         return repr(self.node)
 
     def __getitem__(self, neighbor: 'MatchingNode[T]') -> Edge[T]:
-        if self._edges is None:
-            self.edges
-        return self._edges[neighbor]
+        return self._edge_map()[neighbor]
 
     def __contains__(self, node):
-        if self._edges is None:
-            self.edges
-        return node in self._edges
+        return node in self._edge_map()
 
     def __hash__(self):
         return hash(self.node)
@@ -242,10 +241,7 @@ class Matching(SetCollection, Bounded, set[Edge[T]], Generic[T]):
         self._edges_by_node[edge.to_node] = edge
 
     def tighten_bounds(self) -> bool:
-        for edge in self:
-            if edge.weight.tighten_bounds():
-                return True
-        return False
+        return any(edge.weight.tighten_bounds() for edge in self)
 
     def bounds(self) -> Range:
         return sum(edge.weight.bounds() for edge in self._edges)
@@ -537,7 +533,7 @@ def min_weight_bipartite_matching(
         dtype = bool
     elif edge_type is float:
         dtype = float
-    elif not edge_type is int:
+    elif edge_type is not int:
         raise ValueError(f"Unexpected edge type: {edge_type}")
     else:
         dtype = get_dtype(min_edge, max_edge)
@@ -551,7 +547,7 @@ def min_weight_bipartite_matching(
     left_matches = linear_sum_assignment(np.array(weights, dtype=dtype), maximize=False)
     return {
         from_index: (to_index, weights[from_index][to_index])
-        for from_index, to_index in zip(*left_matches)
+        for from_index, to_index in zip(*left_matches, strict=True)
         if not has_null_edges or weights[from_index][to_index] < null_edge_value
     }
 
@@ -698,7 +694,4 @@ class WeightedBipartiteMatcher(Bounded, Generic[T]):
                 return True
             _ = self.matching     # This computes the minimum weight matching
             return True
-        for (_, (_, edge)) in self.matching.items():
-            if edge.tighten_bounds():
-                return True
-        return False
+        return any(edge.tighten_bounds() for _, (_, edge) in self.matching.items())

--- a/graphtage/matching.py
+++ b/graphtage/matching.py
@@ -35,18 +35,21 @@ Example:
 
 import itertools
 from abc import ABCMeta, abstractmethod
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from collections.abc import Set as SetCollection
-from typing import Callable, Dict, Generic, Iterable, Iterator, List
-from typing import Mapping, Optional, Sequence, Set, Tuple, TypeVar, Union
+from typing import (
+    Generic,
+    TypeVar,
+    Union,
+)
 
 import numpy as np
 from scipy.optimize import linear_sum_assignment
 
-from .bounds import Bounded, make_distinct, Range, repeat_until_tightened
+from .bounds import Bounded, Range, make_distinct, repeat_until_tightened
 from .bounds import sort as bounds_sort
 from .fibonacci import FibonacciHeap
-from .utils import smallest, largest
-
+from .utils import largest, smallest
 
 T = TypeVar('T')
 
@@ -94,11 +97,11 @@ class MatchingNode(Generic[T], metaclass=ABCMeta):
         self.node = node
         self.matcher = matcher
         self.weight = Range()
-        self._edges: Optional[Dict[MatchingNode[T], Edge[T]]] = None
+        self._edges: dict[MatchingNode[T], Edge[T]] | None = None
         self.potential: int = 0
 
     @abstractmethod
-    def construct_edges(self) -> Dict['MatchingNode[T]', Edge[T]]:
+    def construct_edges(self) -> dict['MatchingNode[T]', Edge[T]]:
         pass
 
     def edges(self) -> Iterable[Edge[T]]:
@@ -130,9 +133,9 @@ class SortedEdges(Generic[T]):
     """A sorted collection of edges."""
     def __init__(self, edges: Iterable[Edge[T]]):
         self._edges = edges
-        self._sorting_iter: Optional[Iterator[Edge]] = None
-        self._sorted: List[Edge[T]] = []
-        self._indexes: Dict[MatchingToNode[T], int] = {}
+        self._sorting_iter: Iterator[Edge] | None = None
+        self._sorted: list[Edge[T]] = []
+        self._indexes: dict[MatchingToNode[T], int] = {}
 
     def _get_next(self) -> bool:
         if self._sorting_iter is None:
@@ -155,7 +158,7 @@ class SortedEdges(Generic[T]):
             pass
         return self._sorted[-1]
 
-    def __getitem__(self, node_or_index: Union['MatchingToNode[T]', int]) -> Union[Edge[T], int]:
+    def __getitem__(self, node_or_index: Union['MatchingToNode[T]', int]) -> Edge[T] | int:
         if isinstance(node_or_index, int):
             while len(self._sorted) <= node_or_index:
                 if not self._get_next():
@@ -170,7 +173,7 @@ class SortedEdges(Generic[T]):
 class MatchingFromNode(Generic[T], MatchingNode[T]):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._sorted_neighbors: Optional[SortedEdges[T]] = None
+        self._sorted_neighbors: SortedEdges[T] | None = None
 
     @property
     def sorted_neighbors(self) -> SortedEdges[T]:
@@ -178,7 +181,7 @@ class MatchingFromNode(Generic[T], MatchingNode[T]):
             self._sorted_neighbors = SortedEdges(self.edges())
         return self._sorted_neighbors
 
-    def construct_edges(self) -> Dict[MatchingNode[T], Edge[T]]:
+    def construct_edges(self) -> dict[MatchingNode[T], Edge[T]]:
         return {
             neighbor: Edge(self, neighbor, edge) for neighbor, edge in (
                 (neighbor, self.matcher.get_edge(self.node, neighbor.node)) for neighbor in self.matcher.to_nodes
@@ -191,7 +194,7 @@ class MatchingFromNode(Generic[T], MatchingNode[T]):
 
 class MatchingToNode(Generic[T], MatchingNode[T]):
     """A node type used in the implementation of [Karp78]_."""
-    def construct_edges(self) -> Dict[MatchingNode[T], Edge[T]]:
+    def construct_edges(self) -> dict[MatchingNode[T], Edge[T]]:
         return {
             from_node: from_node[self] for from_node in self.matcher.from_nodes if self in from_node
         }
@@ -204,10 +207,10 @@ class Matching(SetCollection, Bounded, set[Edge[T]], Generic[T]):
     """An abstract base class used by the partial implementation of [Karp78]_."""
     def __init__(self):
         super().__init__()
-        self._edges: Set[Edge[T]] = set()
-        self._edges_by_node: Dict[MatchingNode[T], Edge[T]] = {}
+        self._edges: set[Edge[T]] = set()
+        self._edges_by_node: dict[MatchingNode[T], Edge[T]] = {}
 
-    def __contains__(self, edge_or_node: Union[Edge[T], MatchingNode[T]]) -> bool:
+    def __contains__(self, edge_or_node: Edge[T] | MatchingNode[T]) -> bool:
         if isinstance(edge_or_node, Edge):
             return edge_or_node in self._edges
         else:
@@ -219,10 +222,10 @@ class Matching(SetCollection, Bounded, set[Edge[T]], Generic[T]):
     def __iter__(self) -> Iterator[Edge[T]]:
         return iter(self._edges)
 
-    def __getitem__(self, node: MatchingNode[T]) -> Optional[Edge[T]]:
+    def __getitem__(self, node: MatchingNode[T]) -> Edge[T] | None:
         return self._edges_by_node.get(node, None)
 
-    def symmetric_difference(self, matching: Set[Edge[T]]) -> 'Matching[T]':
+    def symmetric_difference(self, matching: set[Edge[T]]) -> 'Matching[T]':
         ret = Matching()
         ret._edges = self._edges.symmetric_difference(matching)
         ret._edges_by_node = {}
@@ -248,7 +251,7 @@ class Matching(SetCollection, Bounded, set[Edge[T]], Generic[T]):
         return sum(edge.weight.bounds() for edge in self._edges)
 
     def __repr__(self):
-        matchings = ", ".join((f"{e.from_node}{e.to_node}" for e in self._edges))
+        matchings = ", ".join(f"{e.from_node}{e.to_node}" for e in self._edges)
         return f'{self.__class__.__name__}<{matchings}>'
 
 
@@ -256,7 +259,7 @@ class PathSet(Matching[T], Generic[T]):
     """A version of a Matching with edge directions overridden, used for [Karp78]_"""
     def __init__(self):
         super().__init__()
-        self._flipped: Dict[MatchingToNode[T], Edge[T]] = {}
+        self._flipped: dict[MatchingToNode[T], Edge[T]] = {}
 
     def add(self, edge: Edge[T], flip_direction: bool):
         if flip_direction:
@@ -266,10 +269,10 @@ class PathSet(Matching[T], Generic[T]):
 
     def _path_to(
             self,
-            from_any_of: Set[MatchingFromNode[T]],
+            from_any_of: set[MatchingFromNode[T]],
             node: MatchingNode[T],
-            history: Optional[Set[Edge[T]]] = None
-    ) -> Optional[Set[Edge[T]]]:
+            history: set[Edge[T]] | None = None
+    ) -> set[Edge[T]] | None:
         if node in from_any_of:
             return set()
         if history is None:
@@ -290,9 +293,9 @@ class PathSet(Matching[T], Generic[T]):
 
     def path_to(
         self,
-        from_any_of: Set[MatchingFromNode[T]],
+        from_any_of: set[MatchingFromNode[T]],
         node: MatchingToNode[T]
-    ) -> Set[Edge[T]]:
+    ) -> set[Edge[T]]:
         ret = self._path_to(from_any_of, node)
         if ret is None:
             return set()
@@ -328,15 +331,15 @@ class WeightedBipartiteMatcherPARTIAL_IMPLEMENTATION(Bounded, Generic[T]):
             self,
             from_nodes: Iterable[T],
             to_nodes: Iterable[T],
-            get_edge: Callable[[T, T], Optional[Bounded]]
+            get_edge: Callable[[T, T], Bounded | None]
     ):
-        self.from_nodes: List[MatchingFromNode[T]] = [MatchingFromNode(self, node) for node in from_nodes]
-        self.to_nodes: List[MatchingToNode[T]] = [MatchingToNode(self, node) for node in to_nodes]
+        self.from_nodes: list[MatchingFromNode[T]] = [MatchingFromNode(self, node) for node in from_nodes]
+        self.to_nodes: list[MatchingToNode[T]] = [MatchingToNode(self, node) for node in to_nodes]
         if len(self.from_nodes) > len(self.to_nodes):
             raise ValueError()
         self.get_edge = get_edge
         self.matching: Matching[T] = Matching()
-        self._min_path_cost: Dict[MatchingNode[T], int] = {}
+        self._min_path_cost: dict[MatchingNode[T], int] = {}
 
     def free_sources(self) -> Iterator[MatchingFromNode[T]]:
         # Given a matching M, a vertex v is called free if it is incident with no edge in M
@@ -386,7 +389,7 @@ class WeightedBipartiteMatcherPARTIAL_IMPLEMENTATION(Bounded, Generic[T]):
 
         path: PathSet[T] = PathSet()
         q: QueueType = FibonacciHeap(key=lambda n: n.cost)
-        r: Set[MatchingNode[T]] = set(self.free_sources())
+        r: set[MatchingNode[T]] = set(self.free_sources())
         for x in r:
             self._min_path_cost[x] = 0
             assert isinstance(x, MatchingFromNode)
@@ -435,10 +438,10 @@ class WeightedBipartiteMatcherPARTIAL_IMPLEMENTATION(Bounded, Generic[T]):
         pass
 
 
-W = TypeVar('W', bound=Union[bool, int, float])
-EdgeType = Union[bool, int, float]
+W = TypeVar('W', bound=bool | int | float)
+EdgeType = bool | int | float
 
-INTEGER_DTYPE_INTERVALS: Tuple[Tuple[int, int, np.dtype], ...] = (
+INTEGER_DTYPE_INTERVALS: tuple[tuple[int, int, np.dtype], ...] = (
     (0, 2**8, np.dtype(np.uint8)),
     (0, 2**16, np.dtype(np.uint16)),
     (0, 2**32, np.dtype(np.uint32)),
@@ -461,8 +464,8 @@ def get_dtype(min_value: int, max_value: int) -> np.dtype:
 def min_weight_bipartite_matching(
         from_nodes: Sequence[T],
         to_nodes: Sequence[T],
-        get_edges: Callable[[T, T], Optional[W]]
-) -> Mapping[int, Tuple[int, EdgeType]]:
+        get_edges: Callable[[T, T], W | None]
+) -> Mapping[int, tuple[int, EdgeType]]:
     """Calculates the minimum weight bipartite matching between two sequences.
 
     Args:
@@ -492,11 +495,11 @@ def min_weight_bipartite_matching(
 
     """
     # Assume that the bipartite graph is dense. If the edges are sparse, consider switching to `scipy.sparse.coo_matrix`
-    weights: List[List[Optional[EdgeType]]] = [[None] * len(to_nodes) for _ in range(len(from_nodes))]
+    weights: list[list[EdgeType | None]] = [[None] * len(to_nodes) for _ in range(len(from_nodes))]
 
-    edge_type: Optional[type] = None
-    max_edge: Optional[EdgeType] = None
-    min_edge: Optional[EdgeType] = None
+    edge_type: type | None = None
+    max_edge: EdgeType | None = None
+    min_edge: EdgeType | None = None
 
     has_null_edges = False
 
@@ -518,7 +521,7 @@ def min_weight_bipartite_matching(
     if has_null_edges:
         if isinstance(edge_type, bool):
             raise ValueError("Null edges are only supported with `int` or `float` edge types, not `bool`. Bipartite graphs with `bool` edge weights must be complete.")
-        null_edge_value: Optional[EdgeType] = max(
+        null_edge_value: EdgeType | None = max(
             sum(weights[row][col] for row in range(len(from_nodes)) if weights[row][col] is not None)
             for col in range(len(to_nodes))
         ) + 1
@@ -568,7 +571,7 @@ class WeightedBipartiteMatcher(Bounded, Generic[T]):
             self,
             from_nodes: Iterable[T],
             to_nodes: Iterable[T],
-            get_edge: Callable[[T, T], Optional[Bounded]]
+            get_edge: Callable[[T, T], Bounded | None]
     ):
         """Initializes the weighted bipartite matcher.
 
@@ -584,20 +587,20 @@ class WeightedBipartiteMatcher(Bounded, Generic[T]):
             to_nodes = tuple(to_nodes)
         self.from_nodes: Sequence[T] = from_nodes
         self.to_nodes: Sequence[T] = to_nodes
-        self.from_node_indexes: Dict[T, int] = {
+        self.from_node_indexes: dict[T, int] = {
             from_node: i for i, from_node in enumerate(from_nodes)
         }
-        self.to_node_indexes: Dict[T, int] = {
+        self.to_node_indexes: dict[T, int] = {
             to_node: i for i, to_node in enumerate(to_nodes)
         }
-        self._edges: Optional[List[List[Optional[Bounded]]]] = None
-        self._match: Optional[Mapping[T, Tuple[T, Bounded]]] = None
+        self._edges: list[list[Bounded | None]] | None = None
+        self._match: Mapping[T, tuple[T, Bounded]] | None = None
         self._edges_are_distinct: bool = False
         self.get_edge = get_edge
-        self._bounds: Optional[Range] = None
+        self._bounds: Range | None = None
 
     @property
-    def edges(self) -> List[List[Optional[Bounded]]]:
+    def edges(self) -> list[list[Bounded | None]]:
         """Returns a dense matrix of the edges in the graph.
 
         This property lazily constructs the edge matrix and memoizes the result.
@@ -645,7 +648,7 @@ class WeightedBipartiteMatcher(Bounded, Generic[T]):
             return True
 
     @property
-    def matching(self) -> Mapping[T, Tuple[T, Bounded]]:
+    def matching(self) -> Mapping[T, tuple[T, Bounded]]:
         """Returns the minimum weight matching.
 
         Returns:

--- a/graphtage/matching.py
+++ b/graphtage/matching.py
@@ -34,7 +34,6 @@ Example:
 """
 
 import itertools
-import sys
 from abc import ABCMeta, abstractmethod
 from collections.abc import Set as SetCollection
 from typing import Callable, Dict, Generic, Iterable, Iterator, List
@@ -201,14 +200,7 @@ class MatchingToNode(Generic[T], MatchingNode[T]):
         return f"\u21A3{self.node!r}"
 
 
-if sys.version_info.major < 3 or sys.version_info.minor < 7:
-    # This is to satisfy Python 3.6's MRO
-    SetType = object
-else:
-    SetType = Set[Edge[T]]
-
-
-class Matching(Generic[T], SetCollection, Bounded, SetType):
+class Matching(SetCollection, Bounded, set[Edge[T]], Generic[T]):
     """An abstract base class used by the partial implementation of [Karp78]_."""
     def __init__(self):
         super().__init__()

--- a/graphtage/multiset.py
+++ b/graphtage/multiset.py
@@ -6,9 +6,10 @@ This is used by :class:`graphtage.MultiSetNode` and :class:`graphtage.DictNode`,
 """
 
 import logging
-from typing import Iterator, List
+from collections.abc import Iterator
 
 import graphtage
+
 from .bounds import Range
 from .edits import Insert, Match, Remove
 from .matching import WeightedBipartiteMatcher
@@ -54,7 +55,7 @@ class MultiSetEdit(SequenceEdit):
                 this to `False` will require a significant amount more computation for larger dictionaries.
 
         """
-        self._matched_kvp_edits: List[Edit] = []
+        self._matched_kvp_edits: list[Edit] = []
         if auto_match_keys:
             to_set = HashableCounter(to_set)
             from_set = HashableCounter(from_set)
@@ -87,7 +88,7 @@ class MultiSetEdit(SequenceEdit):
                 "Matching %d unordered elements against %d requires costing %d pairs, which can take a long time",
                 sum(self.to_remove.values()), sum(self.to_insert.values()), num_pairs
             )
-        self._edits: List[Edit] = [Match(n, n, 0) for n in to_match.elements()]
+        self._edits: list[Edit] = [Match(n, n, 0) for n in to_match.elements()]
         self._matcher = WeightedBipartiteMatcher(
             from_nodes=self.to_remove.elements(),
             to_nodes=self.to_insert.elements(),

--- a/graphtage/multiset.py
+++ b/graphtage/multiset.py
@@ -31,7 +31,7 @@ class MultiSetEdit(SequenceEdit):
 
     """
 
-    __slots__ = ('_matched_kvp_edits', 'to_insert', 'to_remove', '_edits', '_matcher')
+    __slots__ = ('_edits', '_matched_kvp_edits', '_matcher', 'to_insert', 'to_remove')
 
     def __init__(
             self,
@@ -60,10 +60,10 @@ class MultiSetEdit(SequenceEdit):
             to_set = HashableCounter(to_set)
             from_set = HashableCounter(from_set)
             to_remove_from = []
-            for f in from_set.keys():
+            for f in from_set:
                 if not isinstance(f, graphtage.KeyValuePairNode):
                     continue
-                for t in to_set.keys():
+                for t in to_set:
                     if not isinstance(t, graphtage.KeyValuePairNode):
                         continue
                     if f.key == t.key:

--- a/graphtage/object_set.py
+++ b/graphtage/object_set.py
@@ -3,8 +3,8 @@ A data structure that can hold a set of unique Python objects, even if those obj
 Uniqueness is determined based upon identity.
 """
 
-from collections.abc import MutableSet
-from typing import Any, Iterable, Set
+from collections.abc import Iterable, MutableSet
+from typing import Any
 
 
 class IdentityHash:
@@ -27,7 +27,7 @@ class ObjectSet(MutableSet):
 
     """
     def __init__(self, initial_objs: Iterable[Any] = ()):
-        self.objs: Set[IdentityHash] = set()
+        self.objs: set[IdentityHash] = set()
         for obj in initial_objs:
             self.add(obj)
 

--- a/graphtage/pickle.py
+++ b/graphtage/pickle.py
@@ -1,10 +1,9 @@
 import os
-from typing import Optional, Union
 
 from fickling.fickle import Interpreter, Pickled, PickleDecodeError
 
 from .graphtage import BuildOptions, Filetype, TreeNode
-from .pydiff import ast_to_tree, PyDiffFormatter
+from .pydiff import PyDiffFormatter, ast_to_tree
 
 
 class Pickle(Filetype):
@@ -22,14 +21,14 @@ class Pickle(Filetype):
             'application/x-python-pickle'
         )
 
-    def build_tree(self, path: str, options: Optional[BuildOptions] = None) -> TreeNode:
+    def build_tree(self, path: str, options: BuildOptions | None = None) -> TreeNode:
         with open(path, "rb") as f:
             pickle = Pickled.load(f)
             interpreter = Interpreter(pickle)
             ast = interpreter.to_ast()
             return ast_to_tree(ast, options)
 
-    def build_tree_handling_errors(self, path: str, options: Optional[BuildOptions] = None) -> Union[str, TreeNode]:
+    def build_tree_handling_errors(self, path: str, options: BuildOptions | None = None) -> str | TreeNode:
         try:
             return self.build_tree(path=path, options=options)
         except PickleDecodeError as e:

--- a/graphtage/plist.py
+++ b/graphtage/plist.py
@@ -1,13 +1,11 @@
 """A :class:`graphtage.Filetype` for parsing, diffing, and rendering Apple plist files."""
 import os
-from xml.parsers.expat import ExpatError
-from typing import Optional, Tuple, Union
-
 from plistlib import dumps, load
+from xml.parsers.expat import ExpatError
 
 from . import json
 from .edits import Edit, EditCollection, Match
-from .graphtage import BoolNode, BuildOptions, Filetype, FloatNode, KeyValuePairNode, IntegerNode, LeafNode, StringNode
+from .graphtage import BoolNode, BuildOptions, Filetype, FloatNode, IntegerNode, KeyValuePairNode, LeafNode, StringNode
 from .printer import Printer
 from .sequences import SequenceFormatter, SequenceNode
 from .tree import ContainerNode, GraphtageFormatter, TreeNode
@@ -50,7 +48,7 @@ class PLISTNode(ContainerNode):
         return 1
 
 
-def build_tree(path: str, options: Optional[BuildOptions] = None, *args, **kwargs) -> PLISTNode:
+def build_tree(path: str, options: BuildOptions | None = None, *args, **kwargs) -> PLISTNode:
     """Constructs a PLIST tree from an PLIST file."""
     with open(path, "rb") as stream:
         data = load(stream)
@@ -91,7 +89,7 @@ class PLISTSequenceFormatter(SequenceFormatter):
     print_MappingNode = print_MultiSetNode
 
 
-def _plist_header_footer() -> Tuple[str, str]:
+def _plist_header_footer() -> tuple[str, str]:
     string = "1234567890"
     encoded = dumps(string).decode("utf-8")
     expected = f"<string>{string}</string>"
@@ -156,14 +154,14 @@ class PLIST(Filetype):
             'application/x-plist'
         )
 
-    def build_tree(self, path: str, options: Optional[BuildOptions] = None) -> TreeNode:
+    def build_tree(self, path: str, options: BuildOptions | None = None) -> TreeNode:
         tree = build_tree(path=path, options=options)
         for node in tree.dfs():
             if isinstance(node, StringNode):
                 node.quoted = False
         return tree
 
-    def build_tree_handling_errors(self, path: str, options: Optional[BuildOptions] = None) -> Union[str, TreeNode]:
+    def build_tree_handling_errors(self, path: str, options: BuildOptions | None = None) -> str | TreeNode:
         try:
             return self.build_tree(path=path, options=options)
         except ExpatError as ee:

--- a/graphtage/plist.py
+++ b/graphtage/plist.py
@@ -52,7 +52,7 @@ def build_tree(path: str, options: BuildOptions | None = None, *args, **kwargs) 
     """Constructs a PLIST tree from an PLIST file."""
     with open(path, "rb") as stream:
         data = load(stream)
-        return PLISTNode(json.build_tree(data, options=options, *args, **kwargs))
+        return PLISTNode(json.build_tree(data, *args, options=options, **kwargs))
 
 
 class PLISTSequenceFormatter(SequenceFormatter):
@@ -105,7 +105,7 @@ PLIST_HEADER, PLIST_FOOTER = _plist_header_footer()
 
 
 class PLISTFormatter(GraphtageFormatter):
-    sub_format_types = [PLISTSequenceFormatter]
+    sub_format_types = (PLISTSequenceFormatter,)
 
     def print(self, printer: Printer, *args, **kwargs):
         # PLIST uses an eight-space indent

--- a/graphtage/printer.py
+++ b/graphtage/printer.py
@@ -15,16 +15,15 @@ Attributes:
 """
 
 import logging
-import os
 import sys
 from abc import abstractmethod
 from collections import defaultdict
 from functools import wraps
-from typing import Any, Dict, List, Optional, Protocol, Set, Type, Union
+from typing import Any, Optional, Protocol, Union
 
 import colorama
 from colorama import Back, Fore, Style
-from colorama.ansi import AnsiFore, AnsiBack, AnsiStyle
+from colorama.ansi import AnsiBack, AnsiFore, AnsiStyle
 
 from .progress import StatusWriter
 from .version import VERSION_STRING
@@ -84,7 +83,7 @@ class CombiningMarkWriter(RawWriter):
         """
         self.parent: RawWriter = parent
         """This writer's parent."""
-        self._marks: Set[str] = set()
+        self._marks: set[str] = set()
         self.enabled: bool = True
         """Whether or not combining marks will be added."""
 
@@ -101,7 +100,7 @@ class CombiningMarkWriter(RawWriter):
         return CombiningMarkContext(self, *combining_marks)
 
     @property
-    def marks(self) -> Set[str]:
+    def marks(self) -> set[str]:
         """Returns the set of combining marks in this writer."""
         return self._marks
 
@@ -143,8 +142,8 @@ class CombiningMarkContext:
     """A context returned by :meth:`CombiningMarkWriter.context`."""
     def __init__(self, writer: CombiningMarkWriter, *combining_marks: str):
         self.writer: CombiningMarkWriter = writer
-        self.marks: Set[str] = set(combining_marks)
-        self._state_before: Optional[Set[str]] = None
+        self.marks: set[str] = set(combining_marks)
+        self._state_before: set[str] | None = None
 
     def __enter__(self) -> CombiningMarkWriter:
         self._state_before = set(self.writer.marks)
@@ -163,9 +162,9 @@ class ANSIContext:
     def __init__(
             self,
             stream: Union[RawWriter, 'ANSIContext'],
-            fore: Optional[AnsiFore] = None,
-            back: Optional[AnsiBack] = None,
-            style: Optional[AnsiStyle] = None,
+            fore: AnsiFore | None = None,
+            back: AnsiBack | None = None,
+            style: AnsiStyle | None = None,
     ):
         """Initializes a context.
 
@@ -180,15 +179,15 @@ class ANSIContext:
         """
         if isinstance(stream, ANSIContext):
             self.stream: RawWriter = stream.stream
-            self._parent: Optional['ANSIContext'] = stream
+            self._parent: ANSIContext | None = stream
         else:
             self.stream: RawWriter = stream
-            self._parent: Optional['ANSIContext'] = None
-        self._fore: Optional[AnsiFore] = fore
-        self._back: Optional[AnsiBack] = back
-        self._style: Optional[AnsiStyle] = style
-        self._start_code: Optional[str] = None
-        self._end_code: Optional[str] = None
+            self._parent: ANSIContext | None = None
+        self._fore: AnsiFore | None = fore
+        self._back: AnsiBack | None = back
+        self._style: AnsiStyle | None = style
+        self._start_code: str | None = None
+        self._end_code: str | None = None
         self.is_applied: bool = False
         """Keeps track of whether this context's options have already been applied to the underlying stream."""
 
@@ -216,7 +215,7 @@ class ANSIContext:
         contexts = ANSI_CONTEXT_STACK[self.stream]
         if contexts:
             if self._parent is None:
-                self._parent: Optional['ANSIContext'] = contexts[-1]
+                self._parent: ANSIContext | None = contexts[-1]
             else:
                 if not self.root.is_applied:
                     self.root._parent = contexts[-1]
@@ -249,7 +248,7 @@ class ANSIContext:
         self._end_code += parent_end_code
 
     @property
-    def fore(self) -> Optional[AnsiFore]:
+    def fore(self) -> AnsiFore | None:
         """The computed foreground color of this context."""
         if self._fore is None and self._parent is not None:
             return self._parent.fore
@@ -257,7 +256,7 @@ class ANSIContext:
             return self._fore
 
     @property
-    def back(self) -> Optional[AnsiBack]:
+    def back(self) -> AnsiBack | None:
         """The computed background color of this context."""
         if self._back is None and self._parent is not None:
             return self._parent.back
@@ -265,7 +264,7 @@ class ANSIContext:
             return self._back
 
     @property
-    def style(self) -> Optional[AnsiStyle]:
+    def style(self) -> AnsiStyle | None:
         """The computed style of this context."""
         if self._style is None and self._parent is not None:
             return self._parent.style
@@ -360,7 +359,7 @@ class HTMLANSIContext(ANSIContext):
         contexts = ANSI_CONTEXT_STACK[self.stream]
         if contexts:
             if self._parent is None:
-                self._parent: Optional['ANSIContext'] = contexts[-1]
+                self._parent: ANSIContext | None = contexts[-1]
             else:
                 if not self.root.is_applied:
                     self.root._parent = contexts[-1]
@@ -392,7 +391,7 @@ class HTMLANSIContext(ANSIContext):
         self._end_code = f"{self._end_code}{parent_end_code}"
 
 
-ONLY_ANSI_FUNCS: Set[str] = set()
+ONLY_ANSI_FUNCS: set[str] = set()
 
 
 def only_ansi(func):
@@ -436,7 +435,7 @@ class NullANSIContext:
         return getattr(self._printer, item)
 
 
-ANSI_CONTEXT_STACK: Dict[Writer, List[ANSIContext]] = defaultdict(list)
+ANSI_CONTEXT_STACK: dict[Writer, list[ANSIContext]] = defaultdict(list)
 
 
 def enable_ansi_support(force_color: bool = False):
@@ -462,10 +461,10 @@ class Printer(StatusWriter, RawWriter):
 
     def __init__(
             self,
-            out_stream: Optional[Writer] = None,
-            ansi_color: Optional[bool] = None,
+            out_stream: Writer | None = None,
+            ansi_color: bool | None = None,
             quiet: bool = False,
-            options: Optional[Dict[str, Any]] = None
+            options: dict[str, Any] | None = None
     ):
         """Initializes a Printer.
 
@@ -484,7 +483,7 @@ class Printer(StatusWriter, RawWriter):
             out_stream=out_stream,
             quiet=quiet
         )
-        self._context_type: Type[ANSIContext] = ANSIContext
+        self._context_type: type[ANSIContext] = ANSIContext
         self.out_stream: CombiningMarkWriter = CombiningMarkWriter(self)
         """The stream wrapped by this printer."""
         self.indents: int = 0
@@ -508,7 +507,7 @@ class Printer(StatusWriter, RawWriter):
         return self._ansi_color
 
     @ansi_color.setter
-    def ansi_color(self, is_color: Optional[bool]):
+    def ansi_color(self, is_color: bool | None):
         if is_color is None:
             self._ansi_color = self.out_stream.isatty()
         else:
@@ -584,7 +583,7 @@ class Printer(StatusWriter, RawWriter):
 class HTMLPrinter(Printer):
     """A Printer that outputs in HTML."""
 
-    def __init__(self, *args, title: Optional[str] = None, **kwargs):
+    def __init__(self, *args, title: str | None = None, **kwargs):
         super().__init__(*args, **kwargs)
         self._context_type = HTMLANSIContext
         self.raw_write("<html>")

--- a/graphtage/printer.py
+++ b/graphtage/printer.py
@@ -376,11 +376,11 @@ class HTMLANSIContext(ANSIContext):
             style += f"background-color: {self.get_back(self._back)};"
         if self._style is not None and (self._parent is None or self._style != self.parent.style):
             if self._style == Style.BRIGHT:
-                style += f"font-weight: bold; opacity: 1.0;"
+                style += "font-weight: bold; opacity: 1.0;"
             elif self._style == Style.DIM:
-                style += f"opacity: 0.6; font-weight: normal;"
+                style += "opacity: 0.6; font-weight: normal;"
             else:
-                style += f"font-weight: normal; opacity: 1.0;"
+                style += "font-weight: normal; opacity: 1.0;"
 
         if style:
             self._start_code = f'{self._start_code}<span style="{style}">'

--- a/graphtage/printer.py
+++ b/graphtage/printer.py
@@ -20,11 +20,7 @@ import sys
 from abc import abstractmethod
 from collections import defaultdict
 from functools import wraps
-from typing import Any, Dict, List, Optional, Set, Type, Union
-if sys.version_info[0] < 3 or sys.version_info[1] < 7:
-    Protocol = object
-else:
-    from typing import Protocol
+from typing import Any, Dict, List, Optional, Protocol, Set, Type, Union
 
 import colorama
 from colorama import Back, Fore, Style

--- a/graphtage/printer.py
+++ b/graphtage/printer.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, List, Optional, Set, Type, Union
 if sys.version_info[0] < 3 or sys.version_info[1] < 7:
     Protocol = object
 else:
-    from typing_extensions import Protocol
+    from typing import Protocol
 
 import colorama
 from colorama import Back, Fore, Style

--- a/graphtage/progress.py
+++ b/graphtage/progress.py
@@ -42,15 +42,15 @@ class StatusWriter(IO[str]):
                     out_stream.fileno() != sys.stderr.fileno() and out_stream.fileno() != sys.stdout.fileno()
             )
             """If :const:`True`, this writer *will not* buffer output and use :func:`tqdm.write`.
-            
+
             This defaults to::
-            
+
                 self.write_raw = self.quiet or (
                     out_stream.fileno() != sys.stderr.fileno() and out_stream.fileno() != sys.stdout.fileno()
                 )
-            
+
             """
-        except io.UnsupportedOperation as e:
+        except io.UnsupportedOperation:
             self.write_raw = True
 
     def tqdm(self, *args, **kwargs) -> tqdm:

--- a/graphtage/progress.py
+++ b/graphtage/progress.py
@@ -2,8 +2,9 @@
 
 import io
 import sys
+from collections.abc import Iterable, Iterator
 from types import TracebackType
-from typing import AnyStr, Iterable, Iterator, IO, List, Optional, TextIO, Type
+from typing import IO, AnyStr, TextIO
 
 from tqdm import tqdm, trange
 
@@ -20,7 +21,7 @@ class StatusWriter(IO[str]):
     written may be lost.
 
     """
-    def __init__(self, out_stream: Optional[TextIO] = None, quiet: bool = False):
+    def __init__(self, out_stream: TextIO | None = None, quiet: bool = False):
         """Initializes a status writer.
 
         Args:
@@ -35,7 +36,7 @@ class StatusWriter(IO[str]):
             out_stream = sys.stdout
         self.status_stream: TextIO = out_stream
         """The status stream to which to print."""
-        self._buffer: List[str] = []
+        self._buffer: list[str] = []
         try:
             self.write_raw = self.quiet or (
                     out_stream.fileno() != sys.stderr.fileno() and out_stream.fileno() != sys.stdout.fileno()
@@ -118,7 +119,7 @@ class StatusWriter(IO[str]):
     def readline(self, limit: int = ...) -> AnyStr:
         return self.status_stream.readline(limit)
 
-    def readlines(self, hint: int = ...) -> List[AnyStr]:
+    def readlines(self, hint: int = ...) -> list[AnyStr]:
         return self.status_stream.readlines(hint)
 
     def seek(self, offset: int, whence: int = ...) -> int:
@@ -130,7 +131,7 @@ class StatusWriter(IO[str]):
     def tell(self) -> int:
         return self.status_stream.tell()
 
-    def truncate(self, size: Optional[int] = ...) -> int:
+    def truncate(self, size: int | None = ...) -> int:
         return self.status_stream.truncate(size)
 
     def writable(self) -> bool:
@@ -161,8 +162,8 @@ class StatusWriter(IO[str]):
         self._reentries += 1
         return self
 
-    def __exit__(self, t: Optional[Type[BaseException]], value: Optional[BaseException],
-                 traceback: Optional[TracebackType]) -> Optional[bool]:
+    def __exit__(self, t: type[BaseException] | None, value: BaseException | None,
+                 traceback: TracebackType | None) -> bool | None:
         self._reentries -= 1
         if self._reentries == 0:
             self.flush(final=True)

--- a/graphtage/pydiff.py
+++ b/graphtage/pydiff.py
@@ -167,7 +167,7 @@ class ASTBuilder(BasicBuilder):
 
     @Builder.expander(ast.Assign)
     def expand_assign(self, node: ast.Assign):
-        return node.targets + [node.value]
+        return [*node.targets, node.value]
 
     @Builder.builder(ast.Assign)
     def build_assign(self, _, children):
@@ -191,7 +191,7 @@ class ASTBuilder(BasicBuilder):
 
     @Builder.expander(ast.Call)
     def expand_call(self, node: ast.Call):
-        return [node.func] + node.args
+        return [node.func, *node.args]
 
     @Builder.builder(ast.Call)
     def build_call(self, _, children: list[TreeNode]):
@@ -278,11 +278,8 @@ class PyObjBuilder(BasicBuilder):
         assert isinstance(name, StringNode)
         name.quoted = False
         assert (len(children) - 1) % 2 == 0
-        members = {
-            attr: value
-            for attr, value in zip(children[1::2], children[2::2])
-        }
-        for attr in members.keys():
+        members = dict(zip(children[1::2], children[2::2], strict=True))
+        for attr in members:
             assert isinstance(attr, StringNode)
             attr.quoted = False
         if self.options.allow_key_edits:
@@ -327,7 +324,7 @@ class PyDictFormatter(JSONDictFormatter):
 class PyImportFormatter(SequenceFormatter):
     is_partial = True
 
-    sub_format_types = [PyListFormatter]
+    sub_format_types = (PyListFormatter,)
 
     def __init__(self):
         super().__init__('', '', ', ')
@@ -354,7 +351,7 @@ class PyImportFormatter(SequenceFormatter):
 class PyObjFormatter(SequenceFormatter):
     is_partial = True
 
-    sub_format_types = [PyListFormatter, PyDictFormatter]
+    sub_format_types = (PyListFormatter, PyDictFormatter)
 
     def __init__(self):
         super().__init__('(', ')', ', ')
@@ -404,14 +401,14 @@ class PyObjFormatter(SequenceFormatter):
 class PyModuleFormatter(SequenceFormatter):
     is_partial = True
 
-    sub_format_types = [PyListFormatter]
+    sub_format_types = (PyListFormatter,)
 
     def __init__(self):
         super().__init__('', '', '')
 
     def items_indent(self, printer: Printer) -> Printer:
         return printer
-    
+
     def item_newline(self, printer: Printer, is_first: bool = False, is_last: bool = False):
         if not is_first:
             printer.newline()
@@ -421,7 +418,7 @@ class PyModuleFormatter(SequenceFormatter):
 
 
 class PyDiffFormatter(GraphtageFormatter):
-    sub_format_types = [PyObjFormatter, PyImportFormatter, PyModuleFormatter, PyListFormatter, PyDictFormatter]
+    sub_format_types = (PyObjFormatter, PyImportFormatter, PyModuleFormatter, PyListFormatter, PyDictFormatter)
 
     def print_PyAlias(self, printer: Printer, node: PyAlias):
         self.print(printer, node.name)

--- a/graphtage/pydiff.py
+++ b/graphtage/pydiff.py
@@ -4,7 +4,8 @@ See :doc:`the documentation on using Graphtage programmatically <library>` for s
 """
 import ast
 import logging
-from typing import Any, List, Optional, Union, Iterator, Iterable
+from collections.abc import Iterable, Iterator
+from typing import Any
 
 from . import Range
 from .ast import Assignment, Call, CallArguments, CallKeywords, Import, KeywordArgument, Module, Subscript
@@ -12,13 +13,19 @@ from .builder import BasicBuilder, Builder
 from .dataclasses import DataClassNode
 from .edits import AbstractCompoundEdit, Edit, Replace
 from .graphtage import (
-    BuildOptions, DictNode, FixedKeyDictNode, KeyValuePairNode, LeafNode, ListNode, MultiSetNode, StringNode
+    BuildOptions,
+    DictNode,
+    FixedKeyDictNode,
+    KeyValuePairNode,
+    LeafNode,
+    ListNode,
+    MultiSetNode,
+    StringNode,
 )
 from .json import JSONDictFormatter, JSONListFormatter
 from .printer import Fore, Printer
 from .sequences import SequenceFormatter
 from .tree import ContainerNode, GraphtageFormatter, TreeNode
-
 
 log = logging.getLogger(__name__)
 
@@ -71,11 +78,11 @@ class PyObjFixedAttributes(FixedKeyDictNode):
         return KeywordArgument(key=key, value=value, allow_key_edits=allow_key_edits)
 
 
-PyObjAttributeMapping = Union[PyObjAttributes, PyObjFixedAttributes]
+PyObjAttributeMapping = PyObjAttributes | PyObjFixedAttributes
 
 
 class PyObj(ContainerNode):
-    def __init__(self, class_name: StringNode, attrs: Optional[PyObjAttributeMapping]):
+    def __init__(self, class_name: StringNode, attrs: PyObjAttributeMapping | None):
         self.class_name: StringNode = class_name
         if attrs is None:
             attrs = PyObjAttributes.from_dict({})
@@ -109,7 +116,7 @@ class PyObj(ContainerNode):
         return f"{self.__class__.__name__}(class_name={self.class_name!r}, attrs={self.attrs!r})"
 
 
-ASTNode = Union[ast.AST, ast.stmt, ast.expr, ast.alias]
+ASTNode = ast.AST | ast.stmt | ast.expr | ast.alias
 
 
 class PyAlias(DataClassNode):
@@ -131,17 +138,17 @@ class ASTBuilder(BasicBuilder):
         yield from node.body
 
     @Builder.builder(ast.Module)
-    def build_module(self, _, children: List[TreeNode]):
+    def build_module(self, _, children: list[TreeNode]):
         return Module(tuple(children))
 
     @Builder.expander(ast.List)
     @Builder.expander(ast.Tuple)
     @Builder.expander(ast.Set)
-    def expand_collection(self, node: Union[ast.List, ast.Tuple, ast.Set]):
+    def expand_collection(self, node: ast.List | ast.Tuple | ast.Set):
         yield from node.elts
 
     @Builder.builder(ast.Set)
-    def build_set(self, _, children: List[TreeNode]):
+    def build_set(self, _, children: list[TreeNode]):
         return MultiSetNode(items=children, auto_match_keys=self.options.auto_match_keys)
 
     @Builder.builder(ast.List)
@@ -178,7 +185,7 @@ class ASTBuilder(BasicBuilder):
 
     @Builder.builder(ast.Constant)
     @Builder.builder(ast.Expr)
-    def build_constant(self, _, children: List[TreeNode]):
+    def build_constant(self, _, children: list[TreeNode]):
         assert len(children) == 1
         return children[0]
 
@@ -187,7 +194,7 @@ class ASTBuilder(BasicBuilder):
         return [node.func] + node.args
 
     @Builder.builder(ast.Call)
-    def build_call(self, _, children: List[TreeNode]):
+    def build_call(self, _, children: list[TreeNode]):
         func_name = children[0]
         if isinstance(func_name, StringNode):
             func_name.quoted = False
@@ -202,7 +209,7 @@ class ASTBuilder(BasicBuilder):
         return node.names
 
     @Builder.builder(ast.ImportFrom)
-    def build_import_from(self, node: ast.ImportFrom, children: List[TreeNode]):
+    def build_import_from(self, node: ast.ImportFrom, children: list[TreeNode]):
         if node.module is None:
             from_name = StringNode("", quoted=False)
         else:
@@ -218,7 +225,7 @@ class ASTBuilder(BasicBuilder):
         return PyAlias(StringNode(node.name, quoted=False), as_name)
 
     @Builder.builder(ast.Attribute)
-    def build_attribute(self, node: ast.Attribute, children: List[TreeNode]):
+    def build_attribute(self, node: ast.Attribute, children: list[TreeNode]):
         assert len(children) == 1
         return PyObjAttribute(children[0], StringNode(node.attr, quoted=False))
 
@@ -228,7 +235,7 @@ class ASTBuilder(BasicBuilder):
         yield from node.values
 
     @Builder.builder(ast.Dict)
-    def build_ast_dict(self, node: ast.Dict, children: List[TreeNode]):
+    def build_ast_dict(self, node: ast.Dict, children: list[TreeNode]):
         return self.build_dict(node, children)
 
     @Builder.expander(ast.Subscript)
@@ -237,11 +244,11 @@ class ASTBuilder(BasicBuilder):
         yield node.slice
 
     @Builder.builder(ast.Subscript)
-    def build_subscript(self, _, children: List[TreeNode]):
+    def build_subscript(self, _, children: list[TreeNode]):
         return Subscript(*children)
 
 
-def ast_to_tree(tree: ast.AST, options: Optional[BuildOptions] = None) -> TreeNode:
+def ast_to_tree(tree: ast.AST, options: BuildOptions | None = None) -> TreeNode:
     """Builds a Graphtage tree from a Python Abstract Syntax Tree.
 
     Args:
@@ -266,7 +273,7 @@ class PyObjBuilder(BasicBuilder):
                 yield attr
                 yield getattr(node, attr)
 
-    def default_builder(self, node: Any, children: List[TreeNode]):
+    def default_builder(self, node: Any, children: list[TreeNode]):
         name = children[0]
         assert isinstance(name, StringNode)
         name.quoted = False
@@ -286,7 +293,7 @@ class PyObjBuilder(BasicBuilder):
         return PyObj(name, dict_node)
 
 
-def build_tree(python_obj: Any, options: Optional[BuildOptions] = None) -> TreeNode:
+def build_tree(python_obj: Any, options: BuildOptions | None = None) -> TreeNode:
     """Builds a Graphtage tree from an arbitrary Python object, even complex custom classes.
 
     Args:
@@ -432,11 +439,11 @@ class PyDiffFormatter(GraphtageFormatter):
             printer.write("[")
 
 
-def diff(from_py_obj, to_py_obj, options: Optional[BuildOptions] = None):
+def diff(from_py_obj, to_py_obj, options: BuildOptions | None = None):
     return build_tree(from_py_obj, options=options).diff(build_tree(to_py_obj, options=options))
 
 
-def print_diff(from_py_obj, to_py_obj, printer: Optional[Printer] = None, options: Optional[BuildOptions] = None):
+def print_diff(from_py_obj, to_py_obj, printer: Printer | None = None, options: BuildOptions | None = None):
     if printer is None:
         printer = Printer()
     d = diff(from_py_obj, to_py_obj, options=options)

--- a/graphtage/search.py
+++ b/graphtage/search.py
@@ -67,7 +67,7 @@ class IterativeTighteningSearch(Bounded, Generic[B]):
         """Returns the best solution the search has thus found.
 
          Returns:
-            Optional[B]: The best solution the search has thus found, or :const:`None` if it has not yet found a
+            B | None: The best solution the search has thus found, or :const:`None` if it has not yet found a
             feasible solution.
 
         """

--- a/graphtage/search.py
+++ b/graphtage/search.py
@@ -13,9 +13,10 @@ smallest integer (*i.e.*, with the fewest possible tightenings).
 
 """
 
-from typing import Generic, Iterator, Optional, TypeVar
+from collections.abc import Iterator
+from typing import Generic, TypeVar
 
-from .bounds import Bounded, NEGATIVE_INFINITY, POSITIVE_INFINITY, Range
+from .bounds import NEGATIVE_INFINITY, POSITIVE_INFINITY, Bounded, Range
 from .fibonacci import FibonacciHeap, HeapNode
 
 B = TypeVar('B', bound=Bounded)
@@ -30,7 +31,7 @@ class IterativeTighteningSearch(Bounded, Generic[B]):
     """
     def __init__(self,
                  possibilities: Iterator[B],
-                 initial_bounds: Optional[Range] = None):
+                 initial_bounds: Range | None = None):
         """Initializes the search.
 
         Args:
@@ -62,7 +63,7 @@ class IterativeTighteningSearch(Bounded, Generic[B]):
         return bool(self._unprocessed or ((self._untightened or self._tightened) and not self.bounds().definitive()))
 
     @property
-    def best_match(self) -> Optional[B]:
+    def best_match(self) -> B | None:
         """Returns the best solution the search has thus found.
 
          Returns:
@@ -82,7 +83,7 @@ class IterativeTighteningSearch(Bounded, Generic[B]):
         else:
             return self._untightened.peek()
 
-    def remove_best(self) -> Optional[B]:
+    def remove_best(self) -> B | None:
         """Removes and returns the current best solution found by the search, if one exists.
 
         This enables one to iteratively sort the input sequence. However, this function is only guaranteed to return

--- a/graphtage/sequences.py
+++ b/graphtage/sequences.py
@@ -2,13 +2,13 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Callable, cast, Dict, Generic, Iterable, Iterator, List, Optional, Sequence, Type, TypeVar
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from typing import Any, Generic, TypeVar, cast
 
 from .bounds import Range, repeat_until_tightened
 from .edits import AbstractCompoundEdit, Insert, Match, Remove
 from .printer import Fore, Printer
 from .tree import ContainerNode, Edit, EditedTreeNode, GraphtageFormatter, TreeNode
-
 
 log = logging.getLogger(__name__)
 
@@ -71,7 +71,7 @@ class FixedLengthSequenceEdit(SequenceEdit):
             from_node: 'SequenceNode',
             to_node: 'SequenceNode'
     ):
-        self._sub_edits: List[Edit] = [from_child.edits(to_child) for from_child, to_child in zip(from_node, to_node)]
+        self._sub_edits: list[Edit] = [from_child.edits(to_child) for from_child, to_child in zip(from_node, to_node)]
 
         if len(from_node) > len(to_node):
             self.to_remove: Sequence[TreeNode] = from_node.children()[-len(from_node) - len(to_node):]
@@ -132,7 +132,7 @@ class SequenceNode(ContainerNode, Generic[T], ABC):
 
         """
         self._children: T = children
-        self.child_indexes: Dict[TreeNode, int] = {
+        self.child_indexes: dict[TreeNode, int] = {
             child: i for i, child in enumerate(self.children())
         }
 
@@ -186,7 +186,7 @@ class SequenceNode(ContainerNode, Generic[T], ABC):
 
     @property
     @abstractmethod
-    def container_type(self) -> Type[T]:
+    def container_type(self) -> type[T]:
         """Returns the container type used to store :attr:`SequenceNode._children`.
 
         This is used for performing a deep copy of this node in the :meth:`SequenceNode.editable_dict` function.
@@ -194,7 +194,7 @@ class SequenceNode(ContainerNode, Generic[T], ABC):
         """
         raise NotImplementedError()
 
-    def editable_dict(self) -> Dict[str, Any]:
+    def editable_dict(self) -> dict[str, Any]:
         """Copies :obj:`self.__dict__`, calling :meth:`TreeNode.editable_dict` on all children.
 
         This is equivalent to::
@@ -253,7 +253,7 @@ class SequenceFormatter(GraphtageFormatter):
             start_symbol: str,
             end_symbol: str,
             delimiter: str,
-            delimiter_callback: Optional[Callable[[Printer], Any]] = None
+            delimiter_callback: Callable[[Printer], Any] | None = None
     ):
         """Initializes a sequence formatter.
 

--- a/graphtage/sequences.py
+++ b/graphtage/sequences.py
@@ -37,7 +37,7 @@ class SequenceEdit(AbstractCompoundEdit, ABC):
         """
         if not isinstance(from_node, SequenceNode):
             raise ValueError(f"from_node must be a SequenceNode, but {from_node!r} is {type(from_node)}!")
-        super().__init__(from_node=from_node, *args, **kwargs)
+        super().__init__(*args, from_node=from_node, **kwargs)
 
     @property
     def sequence(self) -> 'SequenceNode':
@@ -64,14 +64,18 @@ class SequenceEdit(AbstractCompoundEdit, ABC):
 class FixedLengthSequenceEdit(SequenceEdit):
     """An edit for sequences that does not consider interleaving."""
 
-    __slots__ = ('_sub_edits', 'to_remove', 'to_insert')
+    __slots__ = ('_sub_edits', 'to_insert', 'to_remove')
 
     def __init__(
             self,
             from_node: 'SequenceNode',
             to_node: 'SequenceNode'
     ):
-        self._sub_edits: list[Edit] = [from_child.edits(to_child) for from_child, to_child in zip(from_node, to_node)]
+        # Not strict: the sequences may differ in length, and the surplus is handled just below
+        # as to_remove or to_insert.
+        self._sub_edits: list[Edit] = [
+            from_child.edits(to_child) for from_child, to_child in zip(from_node, to_node, strict=False)
+        ]
 
         if len(from_node) > len(to_node):
             self.to_remove: Sequence[TreeNode] = from_node.children()[-len(from_node) - len(to_node):]
@@ -137,7 +141,7 @@ class SequenceNode(ContainerNode, Generic[T], ABC):
         }
 
     def children(self) -> Sequence[TreeNode]:
-        if isinstance(self._children, list) or isinstance(self._children, tuple):
+        if isinstance(self._children, (list, tuple)):
             return self._children
         else:
             return super().children()

--- a/graphtage/toml.py
+++ b/graphtage/toml.py
@@ -98,7 +98,7 @@ class TOMLMapping:
         if self.parent is None:
             return ()
         else:
-            return self.parent.name_segments + (self.parent_name,)
+            return (*self.parent.name_segments, self.parent_name)
 
     def items(self) -> Iterator[KeyValuePairNode]:
         inserted = ()
@@ -129,7 +129,7 @@ class TOMLMapping:
 
 
 class TOMLFormatter(GraphtageFormatter):
-    sub_format_types = [TOMLListFormatter, TOMLStringFormatter]
+    sub_format_types = (TOMLListFormatter, TOMLStringFormatter)
 
     def print(self, printer: Printer, *args, **kwargs):
         # TOML has optional indentation; make it only two spaces, if we use it:

--- a/graphtage/toml.py
+++ b/graphtage/toml.py
@@ -1,6 +1,7 @@
 import itertools
 import os
-from typing import Iterator, Optional, Tuple, Union
+from collections.abc import Iterator
+from typing import Optional
 
 import toml
 
@@ -11,8 +12,8 @@ from .sequences import SequenceFormatter
 from .tree import GraphtageFormatter, TreeNode
 
 
-def build_tree(path: str, options: Optional[BuildOptions]) -> TreeNode:
-    with open(path, 'r') as f:
+def build_tree(path: str, options: BuildOptions | None) -> TreeNode:
+    with open(path) as f:
         return json.build_tree(toml.load(f), options)
 
 
@@ -86,14 +87,14 @@ class TOMLMapping:
             self,
             mapping: MappingNode,
             parent: Optional['TOMLMapping'] = None,
-            parent_name: Optional[TreeNode] = None
+            parent_name: TreeNode | None = None
     ):
         self.mapping: MappingNode = mapping
-        self.parent: Optional[TOMLMapping] = parent
-        self.parent_name: Optional[TreeNode] = parent_name
+        self.parent: TOMLMapping | None = parent
+        self.parent_name: TreeNode | None = parent_name
 
     @property
-    def name_segments(self) -> Tuple[TreeNode, ...]:
+    def name_segments(self) -> tuple[TreeNode, ...]:
         if self.parent is None:
             return ()
         else:
@@ -187,11 +188,11 @@ class TOML(Filetype):
             'text/toml'
         )
 
-    def build_tree(self, path: str, options: Optional[BuildOptions] = None) -> TreeNode:
+    def build_tree(self, path: str, options: BuildOptions | None = None) -> TreeNode:
         """Equivalent to :func:`build_tree`"""
         return build_tree(path, options=options)
 
-    def build_tree_handling_errors(self, path: str, options: Optional[BuildOptions] = None) -> Union[str, TreeNode]:
+    def build_tree_handling_errors(self, path: str, options: BuildOptions | None = None) -> str | TreeNode:
         try:
             return self.build_tree(path=path, options=options)
         except (IndexError, TypeError, ValueError) as e:

--- a/graphtage/tree.py
+++ b/graphtage/tree.py
@@ -1,15 +1,20 @@
 import itertools
 import logging
-from abc import abstractmethod, ABC, ABCMeta
+from abc import ABC, ABCMeta, abstractmethod
+from collections.abc import Callable, Iterable, Iterator, Sequence, Sized
 from functools import wraps
 from typing import (
-    Any, Callable, Dict, Iterable, Iterator, List, Optional, Sequence, Sized, Tuple, Type, TypeVar, Union
+    Any,
+    Optional,
+    Protocol,
+    TypeVar,
+    Union,
+    runtime_checkable,
 )
-from typing import Protocol, runtime_checkable
 
 from .bounds import Bounded, Range
-from .formatter import Formatter, FORMATTERS
-from .printer import get_default_printer, Printer
+from .formatter import FORMATTERS, Formatter
+from .printer import Printer, get_default_printer
 
 log = logging.getLogger(__name__)
 
@@ -35,20 +40,20 @@ class GraphtageFormatter(FormatterType):
         """
         if isinstance(node_or_edit, Edit):
             if with_edits:
-                edit: Optional[Edit] = node_or_edit
+                edit: Edit | None = node_or_edit
             else:
-                edit: Optional[Edit] = None
+                edit: Edit | None = None
             node: TreeNode = node_or_edit.from_node
         elif with_edits:
             if isinstance(node_or_edit, EditedTreeNode) and \
                     node_or_edit.edit is not None and node_or_edit.edit.has_non_zero_cost():
-                edit: Optional[Edit] = node_or_edit.edit
+                edit: Edit | None = node_or_edit.edit
                 node: TreeNode = node_or_edit
             else:
-                edit: Optional[Edit] = None
+                edit: Edit | None = None
                 node: TreeNode = node_or_edit
         else:
-            edit: Optional[Edit] = None
+            edit: Edit | None = None
             node: TreeNode = node_or_edit
         if edit is not None:
             # First, see if we have a specialized formatter for this edit:
@@ -257,10 +262,10 @@ class EditedTreeNode:
     """
     def __init__(self):
         self.removed: bool = False
-        self.inserted: List[TreeNode] = []
-        self.matched_to: Optional[TreeNode] = None
-        self.edit_list: List[Edit] = []
-        self.edit: Optional[Edit] = None
+        self.inserted: list[TreeNode] = []
+        self.matched_to: TreeNode | None = None
+        self.edit_list: list[Edit] = []
+        self.edit: Edit | None = None
 
     @property
     def edited(self) -> bool:
@@ -292,9 +297,9 @@ class EditedTreeNode:
 class TreeNodeMeta(ABCMeta):
     def __init__(cls, name, *args, **kwargs):
         super().__init__(name, *args, **kwargs)
-        cls._edited_type: Optional[Type[Union[EditedTreeNode, T]]] = None
+        cls._edited_type: type[EditedTreeNode | T] | None = None
 
-    def edited_type(self) -> Type[Union[EditedTreeNode, T]]:
+    def edited_type(self) -> type[EditedTreeNode | T]:
         """Dynamically constructs a new class that is *both* a :class:`TreeNode` *and* an :class:`EditedTreeNode`.
 
         The edited type's member variables are populated by the result of :meth:`TreeNode.editable_dict` of the
@@ -339,7 +344,7 @@ class TreeNode(metaclass=TreeNodeMeta):
     """
     _total_size = None
     _parent: Optional["TreeNode"] = None
-    _edit_modifiers: Optional[List[Callable[["TreeNode", "TreeNode"], Optional[Edit]]]] = None
+    _edit_modifiers: list[Callable[["TreeNode", "TreeNode"], Edit | None]] | None = None
 
     @property
     def edited(self) -> bool:
@@ -377,7 +382,7 @@ class TreeNode(metaclass=TreeNodeMeta):
 
     def copy(self: T) -> T:
         """Creates a deep copy of this node"""
-        work: List[Tuple[TreeNode, List[TreeNode], List[TreeNode]]] = [(self, [], list(reversed(self.children())))]
+        work: list[tuple[TreeNode, list[TreeNode], list[TreeNode]]] = [(self, [], list(reversed(self.children())))]
         while work:
             node, processed_children, remaining_children = work.pop()
             if not remaining_children:
@@ -473,13 +478,13 @@ class TreeNode(metaclass=TreeNodeMeta):
         """
         raise NotImplementedError()
 
-    def add_edit_modifier(self, modifier: Callable[["TreeNode", "TreeNode"], Optional[Edit]]):
+    def add_edit_modifier(self, modifier: Callable[["TreeNode", "TreeNode"], Edit | None]):
         if self._edit_modifiers is None:
             self._edit_modifiers = []
             self.edits = self._edits_with_modifiers
         self._edit_modifiers.append(modifier)
 
-    def make_edited(self) -> Union[EditedTreeNode, T]:
+    def make_edited(self) -> EditedTreeNode | T:
         """Returns a new, copied instance of this node that is also an instance of :class:`EditedTreeNode`.
 
         This is equivalent to::
@@ -498,7 +503,7 @@ class TreeNode(metaclass=TreeNodeMeta):
         assert isinstance(ret, EditedTreeNode)
         return ret
 
-    def editable_dict(self) -> Dict[str, Any]:
+    def editable_dict(self) -> dict[str, Any]:
         """Copies :obj:`self.__dict__`, calling :meth:`TreeNode.editable_dict` on any :class:`TreeNode` objects therein.
 
         This is equivalent to::
@@ -521,7 +526,7 @@ class TreeNode(metaclass=TreeNodeMeta):
                     ret[key] = value.make_edited()
         return ret
 
-    def get_all_edit_contexts(self, node: "TreeNode") -> Iterator[Tuple[Tuple["TreeNode", ...], Edit]]:
+    def get_all_edit_contexts(self, node: "TreeNode") -> Iterator[tuple[tuple["TreeNode", ...], Edit]]:
         """Returns an iterator over all edit contexts that will transform this node into the provided node.
 
         Args:
@@ -543,7 +548,7 @@ class TreeNode(metaclass=TreeNodeMeta):
                 new_range = new_bounds.upper_bound - new_bounds.lower_bound
                 t.update(prev_range - new_range)
                 prev_range = new_range
-        edit_stack: List[Tuple[Tuple[TreeNode, ...], Edit]] = [((node,), edit)]
+        edit_stack: list[tuple[tuple[TreeNode, ...], Edit]] = [((node,), edit)]
         while edit_stack:
             ancestors, edit = edit_stack.pop()
             if isinstance(edit, CompoundEdit):
@@ -569,7 +574,7 @@ class TreeNode(metaclass=TreeNodeMeta):
         for _, edit in self.get_all_edit_contexts(node):
             yield edit
 
-    def diff(self: T, node: 'TreeNode') -> Union[EditedTreeNode, T]:
+    def diff(self: T, node: 'TreeNode') -> EditedTreeNode | T:
         """Performs a diff against the provided node.
 
         Args:

--- a/graphtage/tree.py
+++ b/graphtage/tree.py
@@ -1,6 +1,5 @@
 import itertools
 import logging
-import sys
 from abc import abstractmethod, ABC, ABCMeta
 from functools import wraps
 from typing import (
@@ -15,11 +14,7 @@ from .printer import get_default_printer, Printer
 log = logging.getLogger(__name__)
 
 
-if sys.version_info.major == 3 and sys.version_info.minor < 7:
-    # For some reason, the type checker breaks on the generic argument in Py3.6 and earlier
-    FormatterType = Formatter
-else:
-    FormatterType = Formatter[Union['TreeNode', 'Edit']]
+FormatterType = Formatter[Union['TreeNode', 'Edit']]
 
 
 class GraphtageFormatter(FormatterType):

--- a/graphtage/tree.py
+++ b/graphtage/tree.py
@@ -553,7 +553,7 @@ class TreeNode(metaclass=TreeNodeMeta):
             ancestors, edit = edit_stack.pop()
             if isinstance(edit, CompoundEdit):
                 for sub_edit in reversed(list(edit.edits())):
-                    edit_stack.append((ancestors + (sub_edit.from_node,), sub_edit))
+                    edit_stack.append(((*ancestors, sub_edit.from_node), sub_edit))
             else:
                 while edit.bounds().lower_bound == 0 and not edit.bounds().definitive() and edit.tighten_bounds():
                     pass
@@ -661,14 +661,14 @@ class ContainerNode(TreeNode, Sized, ABC):
         super().__init_subclass__(**kwargs)
         # wrap the subclass's __init__ function to auto-set the parents of its children
         if "__init__" in cls.__dict__ and cls.__init__ is not object.__init__:
-            orig_init = getattr(cls, "__init__")
+            orig_init = cls.__init__
 
             @wraps(orig_init)
             def wrapped(self: ContainerNode, *args, **kw):
                 if hasattr(self, "_container_initializing") and self._container_initializing:
                     first_init = False
                 else:
-                    setattr(self, "_container_initializing", True)
+                    self._container_initializing = True
                     first_init = True
                 ret = orig_init(self, *args, **kw)
                 if first_init:

--- a/graphtage/tree.py
+++ b/graphtage/tree.py
@@ -308,7 +308,7 @@ class TreeNodeMeta(ABCMeta):
             new_node.__dict__ = dict(wrapped_tree_node.editable_dict())
 
         Returns:
-            Type[Union[EditedTreeNode, T]]: A class that is *both* a :class:`TreeNode` *and* an :class:`EditedTreeNode`.
+            type[EditedTreeNode | T]: A class that is *both* a :class:`TreeNode` *and* an :class:`EditedTreeNode`.
             Its constructor accepts a :class:`TreeNode` that it will wrap.
 
         """
@@ -492,7 +492,7 @@ class TreeNode(metaclass=TreeNodeMeta):
             return self.__class__.edited_type()(self)
 
         Returns:
-            Union[EditedTreeNode, T]: A copied version of this node that is also an instance of :class:`EditedTreeNode`
+            EditedTreeNode | T: A copied version of this node that is also an instance of :class:`EditedTreeNode`
             and thereby mutable.
 
         """
@@ -581,7 +581,7 @@ class TreeNode(metaclass=TreeNodeMeta):
             node: The node against which to perform the diff.
 
         Returns:
-            Union[EditedTreeNode, T]: An edited version of this node with all edits being
+            EditedTreeNode | T: An edited version of this node with all edits being
             :meth:`completed <Edit.is_complete>`.
 
         """

--- a/graphtage/tree.py
+++ b/graphtage/tree.py
@@ -6,7 +6,7 @@ from functools import wraps
 from typing import (
     Any, Callable, Dict, Iterable, Iterator, List, Optional, Sequence, Sized, Tuple, Type, TypeVar, Union
 )
-from typing_extensions import Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 from .bounds import Bounded, Range
 from .formatter import Formatter, FORMATTERS

--- a/graphtage/utils.py
+++ b/graphtage/utils.py
@@ -6,9 +6,11 @@ import tempfile as tf
 from collections import Counter, OrderedDict
 from collections.abc import Iterable
 from collections.abc import Sized as AbstractSized
-from typing import Any, Callable, Dict, Generic, Optional, IO, Iterator, Mapping, MutableMapping, Tuple, TypeVar, Union
+from typing import (
+    Any, Callable, Dict, Generic, IO, Iterator, Mapping, MutableMapping, Optional, Protocol, Tuple, TypeVar,
+    Union
+)
 from typing import Iterable as IterableType
-from typing_extensions import Protocol
 import typing
 
 from .fibonacci import FibonacciHeap, MaxFibonacciHeap

--- a/graphtage/utils.py
+++ b/graphtage/utils.py
@@ -252,7 +252,7 @@ class SparseMatrix(Sized, Generic[T], Mapping[int, MutableMapping[int, T | None]
                 col: The index of the column to get.
 
             Returns:
-                Optional[T]: The value of the column, or the default value if it has not yet been set.
+                T | None: The value of the column, or the default value if it has not yet been set.
 
             Raises:
                 IndexError: If :attr:`self.num_cols <SparseMatrixRow.num_cols>` is not :const:`None` and :obj:`col` is
@@ -312,7 +312,7 @@ class SparseMatrix(Sized, Generic[T], Mapping[int, MutableMapping[int, T | None]
             row: The index of the row to get.
 
         Returns:
-            MutableMapping[int, Optional[T]]: The contents of the row.
+            MutableMapping[int, T | None]: The contents of the row.
 
         Raises:
             IndexError: If :attr:`self.num_rows <SparseMatrix.num_rows>` is not :const:`None` and :obj:`row` is

--- a/graphtage/utils.py
+++ b/graphtage/utils.py
@@ -3,15 +3,17 @@
 import os
 import sys
 import tempfile as tf
+import typing
 from collections import Counter, OrderedDict
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
 from collections.abc import Sized as AbstractSized
 from typing import (
-    Any, Callable, Dict, Generic, IO, Iterator, Mapping, MutableMapping, Optional, Protocol, Tuple, TypeVar,
-    Union
+    IO,
+    Any,
+    Generic,
+    Protocol,
+    TypeVar,
 )
-from typing import Iterable as IterableType
-import typing
 
 from .fibonacci import FibonacciHeap, MaxFibonacciHeap
 
@@ -168,20 +170,20 @@ class OrderedCounter(Counter, OrderedDict):
         return super().elements()
 
 
-class SparseMatrix(Sized, Generic[T], Mapping[int, MutableMapping[int, Optional[T]]]):
+class SparseMatrix(Sized, Generic[T], Mapping[int, MutableMapping[int, T | None]]):
     """A sparse matrix that can store arbitrary Python objects.
 
     For sparse matrices storing homogeneous items and/or native types, it is more efficient to use an implementation
     like a `scipy sparse matrix <https://docs.scipy.org/doc/scipy/reference/sparse.html>`__.
 
     """
-    class SparseMatrixRow(Sized, MutableMapping[int, Optional[T]]):
+    class SparseMatrixRow(Sized, MutableMapping[int, T | None]):
         """A row of a sparse matrix."""
         def __init__(
                 self,
                 row_num: int,
-                num_cols: Optional[int] = None,
-                default_value: Optional[T] = None
+                num_cols: int | None = None,
+                default_value: T | None = None
         ):
             """Initializes a sparse matrix row.
 
@@ -193,11 +195,11 @@ class SparseMatrix(Sized, Generic[T], Mapping[int, MutableMapping[int, Optional[
             """
             self.row_num: int = row_num
             """The index of this row."""
-            self.row: Dict[int, Optional[T]] = {}
+            self.row: dict[int, T | None] = {}
             """Data structure holding the contents of this row."""
-            self.num_cols: Optional[int] = num_cols
+            self.num_cols: int | None = num_cols
             """The number of columns in this row."""
-            self.default_value: Optional[T] = default_value
+            self.default_value: T | None = default_value
             """The default value for this row."""
 
         def shape(self) -> int:
@@ -244,7 +246,7 @@ class SparseMatrix(Sized, Generic[T], Mapping[int, MutableMapping[int, Optional[
             """Iterates over the indexes of columns that have been set in this row."""
             return iter(self.row)
 
-        def __getitem__(self, col: int) -> Optional[T]:
+        def __getitem__(self, col: int) -> T | None:
             """Returns the value of the given column of this row.
 
             Args:
@@ -275,9 +277,9 @@ class SparseMatrix(Sized, Generic[T], Mapping[int, MutableMapping[int, Optional[
 
     def __init__(
             self,
-            num_rows: Optional[int] = None,
-            num_cols: Optional[int] = None,
-            default_value: Optional[T] = None
+            num_rows: int | None = None,
+            num_cols: int | None = None,
+            default_value: T | None = None
     ):
         """Initializes a sparse matrix.
 
@@ -286,15 +288,15 @@ class SparseMatrix(Sized, Generic[T], Mapping[int, MutableMapping[int, Optional[
             num_cols: An optional bound on the number of columns.
             default_value: An optional default value to return if cells are accessed before they are set.
         """
-        self.rows: Dict[int, SparseMatrix[T].SparseMatrixRow] = {}
+        self.rows: dict[int, SparseMatrix[T].SparseMatrixRow] = {}
         """The rows of this matrix."""
-        self.num_rows: Optional[int] = num_rows
+        self.num_rows: int | None = num_rows
         """The number of rows in this matrix, or :const:`None` if there is no bound."""
-        self.num_cols: Optional[int] = num_cols
+        self.num_cols: int | None = num_cols
         """The number of columns in this matrox, or :const:`None` if there is no bound."""
-        self.default_value: Optional[T] = default_value
+        self.default_value: T | None = default_value
         """The default value to return if cells are accessed before they are set."""
-        self._max_row: Optional[int] = None
+        self._max_row: int | None = None
 
     def clear(self):
         """Clears the contents of this matrix."""
@@ -304,7 +306,7 @@ class SparseMatrix(Sized, Generic[T], Mapping[int, MutableMapping[int, Optional[
         """Calculates the approximate memory footprint of this matrix in bytes."""
         return sys.getsizeof(self) + getsizeof(self.rows)
 
-    def __getitem__(self, row: int) -> MutableMapping[int, Optional[T]]:
+    def __getitem__(self, row: int) -> MutableMapping[int, T | None]:
         """Returns the value of the given row of this matrix.
 
         Args:
@@ -344,7 +346,7 @@ class SparseMatrix(Sized, Generic[T], Mapping[int, MutableMapping[int, Optional[
         else:
             return 0
 
-    def __iter__(self) -> Iterator[MutableMapping[int, Optional[T]]]:
+    def __iter__(self) -> Iterator[MutableMapping[int, T | None]]:
         for i in range(len(self)):
             yield self[i]
 
@@ -352,7 +354,7 @@ class SparseMatrix(Sized, Generic[T], Mapping[int, MutableMapping[int, Optional[
         """Counts the number of elements in this matrix that have been explicitly set."""
         return sum(len(row.row) for row in self.rows.values())
 
-    def shape(self) -> Tuple[int, int]:
+    def shape(self) -> tuple[int, int]:
         """Returns the (number of rows, number of columns) of this matrix."""
         if self.num_rows is None:
             if self.rows:
@@ -389,7 +391,7 @@ class Tempfile:
         foo
 
     """
-    def __init__(self, contents: bytes, prefix: Optional[str] = None, suffix: Optional[str] = None):
+    def __init__(self, contents: bytes, prefix: str | None = None, suffix: str | None = None):
         """Initializes a Tempfile
 
         Args:
@@ -397,10 +399,10 @@ class Tempfile:
             prefix: An optional prefix for the filename.
             suffix: An optional suffix for the filename.
         """
-        self._temp: Optional[IO] = None
+        self._temp: IO | None = None
         self._data: bytes = contents
-        self._prefix: Optional[str] = prefix
-        self._suffix: Optional[str] = suffix
+        self._prefix: str | None = prefix
+        self._suffix: str | None = suffix
 
     def __enter__(self) -> str:
         """Constructs a tempfile, returning the path to the file."""
@@ -417,7 +419,7 @@ class Tempfile:
             self._temp = None
 
 
-def smallest(*sequence: Union[T, IterableType[T]], n: int = 1, key: Optional[Callable[[T], Any]] = None) -> Iterator[T]:
+def smallest(*sequence: T | Iterable[T], n: int = 1, key: Callable[[T], Any] | None = None) -> Iterator[T]:
     if len(sequence) == 1 and isinstance(sequence, Iterable):
         sequence = sequence[0]
 
@@ -436,7 +438,7 @@ def smallest(*sequence: Union[T, IterableType[T]], n: int = 1, key: Optional[Cal
         yield heap.pop()
 
 
-def largest(*sequence: Union[T, IterableType[T]], n: int = 1, key: Optional[Callable[[T], Any]] = None) -> Iterator[T]:
+def largest(*sequence: T | Iterable[T], n: int = 1, key: Callable[[T], Any] | None = None) -> Iterator[T]:
     if len(sequence) == 1 and isinstance(sequence[0], Iterable):
         sequence = sequence[0]
 

--- a/graphtage/utils.py
+++ b/graphtage/utils.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import tempfile as tf
-import typing
 from collections import Counter, OrderedDict
 from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
 from collections.abc import Sized as AbstractSized
@@ -64,7 +63,7 @@ def getsizeof(obj) -> int:
         return sys.getsizeof(obj)
 
 
-class HashableCounter(Generic[T], typing.Counter[T], Counter):
+class HashableCounter(Generic[T], Counter[T]):
     """A :class:`Counter` that supports being hashed even though it is mutable."""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/graphtage/utils.py
+++ b/graphtage/utils.py
@@ -55,7 +55,7 @@ def getsizeof(obj) -> int:
     """
     if hasattr(obj, 'getsizeof'):
         return obj.getsizeof()
-    elif isinstance(obj, list) or isinstance(obj, tuple):
+    elif isinstance(obj, (list, tuple)):
         return sys.getsizeof(obj) + sum(getsizeof(i) for i in obj)
     elif isinstance(obj, dict):
         return sys.getsizeof(obj) + sum(getsizeof(key) + getsizeof(value) for key, value in obj.items())
@@ -137,7 +137,7 @@ class OrderedCounter(Counter, OrderedDict):
         return h
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, OrderedDict(self))
+        return f'{self.__class__.__name__}({OrderedDict(self)!r})'
 
     def __reduce__(self):
         return self.__class__, (OrderedDict(self),)

--- a/graphtage/xml.py
+++ b/graphtage/xml.py
@@ -89,10 +89,7 @@ class XMLElementEdit(AbstractCompoundEdit):
             return True
         elif self.attrib_edit.tighten_bounds():
             return True
-        elif self.child_edit.tighten_bounds():
-            return True
-        else:
-            return False
+        return bool(self.child_edit.tighten_bounds())
 
 
 class XMLElementObj:
@@ -217,9 +214,9 @@ class XMLElement(ContainerNode):
     def children(self) -> Collection[TreeNode]:
         ret = (self.tag, self.attrib)
         if self.text is not None:
-            return ret + (self.text, self._children)
+            return (*ret, self.text, self._children)
         else:
-            return ret + (self._children,)
+            return (*ret, self._children)
 
     def __iter__(self) -> Iterator[TreeNode]:
         return iter(self.children())
@@ -370,7 +367,7 @@ class XMLStringFormatter(StringFormatter):
 
 
 class XMLFormatter(GraphtageFormatter):
-    sub_format_types = [XMLStringFormatter, XMLChildFormatter, XMLElementAttribFormatter]
+    sub_format_types = (XMLStringFormatter, XMLChildFormatter, XMLElementAttribFormatter)
 
     def _print_text(self, element: XMLElement, printer: Printer):
         if element.text is None:
@@ -472,4 +469,4 @@ def _json_print_XMLElement(self: JSONFormatter, printer: Printer, node: XMLEleme
     self.print(printer, DictNode(kvps))
 
 
-setattr(JSONFormatter, "print_XMLElement", _json_print_XMLElement)
+JSONFormatter.print_XMLElement = _json_print_XMLElement

--- a/graphtage/xml.py
+++ b/graphtage/xml.py
@@ -10,12 +10,22 @@ accepted by this module.
 import html
 import os
 import xml.etree.ElementTree as ET
-from typing import Collection, Dict, Optional, Iterator, Sequence, Union
+from collections.abc import Collection, Iterator, Sequence
 
 from .bounds import Range
 from .edits import AbstractCompoundEdit, Insert, Match, Remove
-from .graphtage import BuildOptions, ContainerNode, DictNode, Filetype, FixedKeyDictNode, KeyValuePairNode, LeafNode, \
-    ListNode, StringFormatter, StringNode
+from .graphtage import (
+    BuildOptions,
+    ContainerNode,
+    DictNode,
+    Filetype,
+    FixedKeyDictNode,
+    KeyValuePairNode,
+    LeafNode,
+    ListNode,
+    StringFormatter,
+    StringNode,
+)
 from .json import JSONFormatter
 from .printer import Fore, Printer
 from .sequences import SequenceFormatter
@@ -36,14 +46,14 @@ class XMLElementEdit(AbstractCompoundEdit):
         self.attrib_edit: Edit = from_node.attrib.edits(to_node.attrib)
         """The edit to transform this element's attributes."""
         if from_node.text is not None and to_node.text is not None:
-            self.text_edit: Optional[Edit] = from_node.text.edits(to_node.text)
+            self.text_edit: Edit | None = from_node.text.edits(to_node.text)
             """The edit to transform this element's text."""
         elif from_node.text is None and to_node.text is not None:
-            self.text_edit: Optional[Edit] = Insert(to_insert=to_node.text, insert_into=from_node)
+            self.text_edit: Edit | None = Insert(to_insert=to_node.text, insert_into=from_node)
         elif to_node.text is None and from_node.text is not None:
-            self.text_edit: Optional[Edit] = Remove(to_remove=from_node.text, remove_from=from_node)
+            self.text_edit: Edit | None = Remove(to_remove=from_node.text, remove_from=from_node)
         else:
-            self.text_edit: Optional[Edit] = None
+            self.text_edit: Edit | None = None
         self.child_edit: Edit = from_node._children.edits(to_node._children)
         """The edit to transform this node's children."""
         super().__init__(
@@ -90,9 +100,9 @@ class XMLElementObj:
     def __init__(
             self,
             tag: str,
-            attrib: Dict[str, str],
-            text: Optional[str] = None,
-            children: Optional[Sequence['XMLElementObj']] = ()
+            attrib: dict[str, str],
+            text: str | None = None,
+            children: Sequence['XMLElementObj'] | None = ()
     ):
         """Initializes an XML Element Object.
 
@@ -104,11 +114,11 @@ class XMLElementObj:
         """
         self.tag: str = tag
         """The tag of this element."""
-        self.attrib: Dict[str, str] = attrib
+        self.attrib: dict[str, str] = attrib
         """The attributes of this element."""
-        self.text: Optional[str] = text
+        self.text: str | None = text
         """The text of this element."""
-        self.children: Optional[Sequence['XMLElementObj']] = children
+        self.children: Sequence[XMLElementObj] | None = children
         """The children of this element."""
 
     def __repr__(self):
@@ -154,8 +164,8 @@ class XMLElement(ContainerNode):
     def __init__(
             self,
             tag: StringNode,
-            attrib: Optional[Dict[StringNode, StringNode]] = None,
-            text: Optional[StringNode] = None,
+            attrib: dict[StringNode, StringNode] | None = None,
+            text: StringNode | None = None,
             children: Sequence['XMLElement'] = (),
             allow_key_edits: bool = True,
             auto_match_keys: bool = True
@@ -184,7 +194,7 @@ class XMLElement(ContainerNode):
             self.attrib = self.attrib.make_edited()
         for key, _ in self.attrib.items():
             key.quoted = False
-        self.text: Optional[StringNode] = text
+        self.text: StringNode | None = text
         """The text of this element."""
         if self.text is not None:
             self.text.quoted = False
@@ -268,8 +278,8 @@ class XMLElement(ContainerNode):
 
 
 def build_tree(
-        path_or_element_tree: Union[str, ET.Element, ET.ElementTree],
-        options: Optional[BuildOptions] = None
+        path_or_element_tree: str | ET.Element | ET.ElementTree,
+        options: BuildOptions | None = None
 ) -> XMLElement:
     """Constructs an XML element node from an XML file."""
     if isinstance(path_or_element_tree, ET.Element):
@@ -420,10 +430,10 @@ class XML(Filetype):
             'text/xml'
         )
 
-    def build_tree(self, path: str, options: Optional[BuildOptions] = None) -> TreeNode:
+    def build_tree(self, path: str, options: BuildOptions | None = None) -> TreeNode:
         return build_tree(path, options)
 
-    def build_tree_handling_errors(self, path: str, options: Optional[BuildOptions] = None) -> Union[str, TreeNode]:
+    def build_tree_handling_errors(self, path: str, options: BuildOptions | None = None) -> str | TreeNode:
         try:
             return self.build_tree(path=path, options=options)
         except ET.ParseError as pe:

--- a/graphtage/yaml.py
+++ b/graphtage/yaml.py
@@ -1,24 +1,34 @@
 """A :class:`graphtage.Filetype` for parsing, diffing, and rendering YAML files."""
 import os
 from io import StringIO
-from typing import Optional, Union
 
-from yaml import dump, load_all, YAMLError
+from yaml import YAMLError, dump, load_all
+
 try:
-    from yaml import CLoader as Loader, CDumper as Dumper
+    from yaml import CDumper as Dumper
+    from yaml import CLoader as Loader
 except ImportError:
-    from yaml import Loader, Dumper
+    from yaml import Dumper, Loader
 
 from . import json
 from .edits import Insert, Match
-from .graphtage import BuildOptions, Filetype, KeyValuePairNode, LeafNode, ListNode, MappingNode, StringNode, \
-    StringEdit, StringFormatter
+from .graphtage import (
+    BuildOptions,
+    Filetype,
+    KeyValuePairNode,
+    LeafNode,
+    ListNode,
+    MappingNode,
+    StringEdit,
+    StringFormatter,
+    StringNode,
+)
 from .printer import Fore, Printer
 from .sequences import SequenceFormatter, SequenceNode
 from .tree import ContainerNode, Edit, GraphtageFormatter, TreeNode
 
 
-def build_tree(path: str, options: Optional[BuildOptions] = None, *args, **kwargs) -> TreeNode:
+def build_tree(path: str, options: BuildOptions | None = None, *args, **kwargs) -> TreeNode:
     """Constructs a YAML tree from an YAML file."""
     with open(path, 'rb') as stream:
         document_stream = load_all(stream, Loader=Loader)
@@ -226,14 +236,14 @@ class YAML(Filetype):
             'text/vnd.yaml'
         )
 
-    def build_tree(self, path: str, options: Optional[BuildOptions] = None) -> TreeNode:
+    def build_tree(self, path: str, options: BuildOptions | None = None) -> TreeNode:
         tree = build_tree(path=path, options=options)
         for node in tree.dfs():
             if isinstance(node, StringNode):
                 node.quoted = False
         return tree
 
-    def build_tree_handling_errors(self, path: str, options: Optional[BuildOptions] = None) -> Union[str, TreeNode]:
+    def build_tree_handling_errors(self, path: str, options: BuildOptions | None = None) -> str | TreeNode:
         try:
             return self.build_tree(path=path, options=options)
         except YAMLError as ye:

--- a/graphtage/yaml.py
+++ b/graphtage/yaml.py
@@ -34,12 +34,12 @@ def build_tree(path: str, options: BuildOptions | None = None, *args, **kwargs) 
         document_stream = load_all(stream, Loader=Loader)
         documents = list(document_stream)
         if len(documents) == 0:
-            return json.build_tree(None, options=options, *args, **kwargs)
+            return json.build_tree(None, *args, options=options, **kwargs)
         elif len(documents) > 1:
-            return json.build_tree(documents, options=options, *args, **kwargs)
+            return json.build_tree(documents, *args, options=options, **kwargs)
         else:
             singleton = documents[0]
-            return json.build_tree(singleton, options=options, *args, **kwargs)
+            return json.build_tree(singleton, *args, options=options, **kwargs)
 
 
 class YAMLListFormatter(SequenceFormatter):
@@ -97,7 +97,7 @@ class YAMLKeyValuePairFormatter(GraphtageFormatter):
 
 class YAMLDictFormatter(SequenceFormatter):
     is_partial = True
-    sub_format_types = [YAMLKeyValuePairFormatter]
+    sub_format_types = (YAMLKeyValuePairFormatter,)
 
     def __init__(self):
         super().__init__('', '', '')
@@ -177,7 +177,7 @@ class YAMLStringFormatter(StringFormatter):
 
 
 class YAMLFormatter(GraphtageFormatter):
-    sub_format_types = [YAMLStringFormatter, YAMLDictFormatter, YAMLListFormatter]
+    sub_format_types = (YAMLStringFormatter, YAMLDictFormatter, YAMLListFormatter)
 
     def print(self, printer: Printer, *args, **kwargs):
         # YAML only gets a two-space indent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,10 @@ dependencies = [
     "scipy>=1.4.0",
     "toml>=0.10.2",
     "tqdm",
-    "typing_extensions>=3.7.4.3",
+    # Graphtage itself needs nothing from typing_extensions. fickling does: fickle.py imports
+    # typing_extensions.Buffer on Python < 3.12 without declaring the dependency, so importing
+    # graphtage.pickle fails on 3.10 and 3.11 unless something else installs it.
+    "typing_extensions; python_version < '3.12'",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
-    "ruff>=0.1.0",
+    "ruff>=0.16.0,<1.0",
     "sphinx>=5.0.0",
     "sphinx_rtd_theme==3.0.2",
     "twine>=4.0.0",
@@ -82,6 +82,8 @@ packages = ["graphtage"]
 [tool.ruff]
 target-version = "py310"
 line-length = 120
+
+[tool.ruff.lint]
 select = [
     "E",     # pycodestyle errors
     "W",     # pycodestyle warnings
@@ -101,13 +103,21 @@ ignore = [
     "SIM108", # use ternary operator instead of if-else block
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "test/**/*.py" = [
     "F401",  # unused imports in tests
     "F841",  # unused variables in tests
 ]
+# The import order here is load-bearing: the star imports must run before the plain submodule
+# imports, because graphtage/ast.py does `from . import DictNode, ...`. The star imports are also
+# what `SUBMODULES_TO_SUBSUME` relies on to hoist submodule classes to the top-level package.
+"graphtage/__init__.py" = [
+    "I001",  # unsorted imports
+    "F401",  # unused imports
+    "F403",  # star imports
+]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["graphtage"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,9 @@ ignore = [
     "B008",  # do not perform function calls in argument defaults
     "B904",  # raise without from inside except
     "SIM108", # use ternary operator instead of if-else block
+    # Collapsing an if/elif chain whose arms are identical turns short, readable branches into
+    # one long unparenthesized and/or expression. Several of these run past 150 characters.
+    "SIM114", # if-with-same-arms
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ dependencies = [
     "colorama",
     "fickling>=0.1.3",
     "intervaltree",
-    "json5==0.9.5",
-    "numpy>=1.19.4",
+    "json5>=0.9.5",
+    "numpy>=1.26",
     "PyYAML",
-    "scipy>=1.4.0",
+    "scipy>=1.11",
     "toml>=0.10.2",
     "tqdm",
     # Graphtage itself needs nothing from typing_extensions. fickling does: fickle.py imports
@@ -47,7 +47,6 @@ dev = [
     "ruff>=0.16.0,<1.0",
     "sphinx>=5.0.0",
     "sphinx_rtd_theme==3.0.2",
-    "twine>=4.0.0",
 ]
 
 [project.scripts]

--- a/test/test_bounds.py
+++ b/test/test_bounds.py
@@ -4,11 +4,11 @@ from unittest import TestCase
 
 from tqdm import trange
 
-from graphtage.bounds import Bounded, make_distinct, Range, sort
+from graphtage.bounds import Bounded, Range, make_distinct, sort
 
 
 class RandomDecreasingRange(Bounded):
-    def __init__(self, fixed_lb: int = 0, fixed_ub: int = 2000000, final_value: Optional[int] = None):
+    def __init__(self, fixed_lb: int = 0, fixed_ub: int = 2000000, final_value: int | None = None):
         if final_value is None:
             self.final_value = random.randint(fixed_lb, fixed_lb + (fixed_ub - fixed_lb) // 2)
         elif final_value < fixed_lb:

--- a/test/test_bounds.py
+++ b/test/test_bounds.py
@@ -67,7 +67,7 @@ class TestBounds(TestCase):
         for _ in trange(100):
             ranges = [RandomDecreasingRange() for _ in range(100)]
             sorted_ranges = sorted(ranges, key=lambda r: r.final_value)
-            for expected, actual in zip(sorted_ranges, sort(ranges)):
+            for expected, actual in zip(sorted_ranges, sort(ranges), strict=True):
                 self.assertEqual(expected.final_value, actual.final_value)
 
     def test_make_distinct(self):

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -1,4 +1,3 @@
-from typing import List
 from unittest import TestCase
 
 from graphtage import BuildOptions, IntegerNode, ListNode, TreeNode, UnorderedListNode
@@ -31,7 +30,7 @@ class TestBuilder(TestCase):
                 yield obj.bar
 
             @Builder.builder(Foo)
-            def build_foo(self, obj: Foo, children: List[TreeNode]):
+            def build_foo(self, obj: Foo, children: list[TreeNode]):
                 test.assertEqual(1, len(children))
                 return children[0]
 

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -1,9 +1,9 @@
 from unittest import TestCase
 
 import graphtage
+from graphtage import expressions
 from graphtage.constraints import MatchIf, MatchUnless
 from graphtage.json import build_tree
-from graphtage import expressions
 
 
 class TestConstraints(TestCase):

--- a/test/test_expressions.py
+++ b/test/test_expressions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from graphtage.expressions import parse, ParseError, StringToken
+from graphtage.expressions import ParseError, StringToken, parse
 
 
 class TestExpressions(TestCase):

--- a/test/test_fibonacci.py
+++ b/test/test_fibonacci.py
@@ -1,6 +1,6 @@
 import random
 from collections import defaultdict
-from typing import Callable, Dict, List, Optional, Set
+from collections.abc import Callable
 from unittest import TestCase
 
 from tqdm import tqdm, trange
@@ -11,8 +11,8 @@ from graphtage.fibonacci import FibonacciHeap, HeapNode, MaxFibonacciHeap
 class TestFibonacciHeap(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.random_list: List[int] = [random.randint(0, 10000) for _ in range(10000)]
-        cls.sorted_list: List[int] = sorted(cls.random_list)
+        cls.random_list: list[int] = [random.randint(0, 10000) for _ in range(10000)]
+        cls.sorted_list: list[int] = sorted(cls.random_list)
 
     def test_duplicate_items(self):
         heap = FibonacciHeap()
@@ -28,7 +28,7 @@ class TestFibonacciHeap(TestCase):
             heap.push(rand_int)
         return heap
 
-    def random_max_heap(self, key: Optional[Callable[[int], int]] = None) -> MaxFibonacciHeap[int, int]:
+    def random_max_heap(self, key: Callable[[int], int] | None = None) -> MaxFibonacciHeap[int, int]:
         heap: FibonacciHeap[int, int] = MaxFibonacciHeap(key=key)
         for rand_int in self.random_list:
             heap.push(rand_int)
@@ -71,10 +71,10 @@ class TestFibonacciHeap(TestCase):
 
     def test_decrease_key(self):
         heap = self.random_heap()
-        nodes_by_value: Dict[int, Set[HeapNode[int, int]]] = defaultdict(set)
+        nodes_by_value: dict[int, set[HeapNode[int, int]]] = defaultdict(set)
         for node in heap.nodes():
             nodes_by_value[node.key].add(node)
-        changes: Dict[int, int] = {}
+        changes: dict[int, int] = {}
         for _ in trange(len(self.random_list)//20):
             while True:
                 random_sorted_index = random.randint(0, len(self.random_list) - 1)

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -194,9 +194,9 @@ class TestFormatting(TestCase):
         obj_stack = []
         ret = TestFormatting._make_random_obj(
             obj_stack,
+            *args,
             force_container_type=force_outer_container_type,
             allow_non_container=force_outer_container_type is None,
-            *args,
             **kwargs
         )
 
@@ -222,12 +222,12 @@ class TestFormatting(TestCase):
                         if force_string_keys:
                             expanding[TestFormatting.make_random_str(*args, **kwargs)] = \
                                 TestFormatting._make_random_obj(
-                                    obj_stack, force_container_type=force_container_type, *args, **kwargs
+                                    obj_stack, *args, force_container_type=force_container_type, **kwargs
                                 )
                         else:
                             expanding[TestFormatting.make_random_non_container(*args, **kwargs)] = \
                                 TestFormatting._make_random_obj(
-                                    obj_stack, force_container_type=force_container_type, *args, **kwargs
+                                    obj_stack, *args, force_container_type=force_container_type, **kwargs
                                 )
             else:
                 if size == 0 and not allow_empty_containers:
@@ -241,12 +241,12 @@ class TestFormatting(TestCase):
                         force_container_type = None
                     for _ in range(size):
                         expanding.append(TestFormatting._make_random_obj(
-                            obj_stack, force_container_type=force_container_type, *args, **kwargs
+                            obj_stack, *args, force_container_type=force_container_type, **kwargs
                         ))
         return ret
 
     def test_formatter_coverage(self):
-        for name in graphtage.FILETYPES_BY_TYPENAME.keys():
+        for name in graphtage.FILETYPES_BY_TYPENAME:
             if not hasattr(self, f'test_{name}_formatting'):
                 self.fail(f"Filetype {name} is missing a `test_{name}_formatting` test function")
 

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -6,7 +6,6 @@ import random
 import time
 from functools import partial, wraps
 from io import StringIO
-from typing import FrozenSet, Optional, Tuple, Type, Union
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -19,11 +18,10 @@ from graphtage import xml
 
 from .timing import run_with_time_limit
 
-
-STR_BYTES: FrozenSet[str] = frozenset([
+STR_BYTES: frozenset[str] = frozenset([
     chr(i) for i in range(32, 127)
 ] + ['\n', '\t', '\r'])
-LETTERS: Tuple[str, ...] = tuple(
+LETTERS: tuple[str, ...] = tuple(
     chr(i) for i in range(ord('a'), ord('z'))
 ) + tuple(
     chr(i) for i in range(ord('A'), ord('Z'))
@@ -139,7 +137,7 @@ class TestFormatting(TestCase):
         return random.choice([True, False])
 
     @staticmethod
-    def make_random_str(exclude_bytes: FrozenSet[str] = frozenset(), allow_empty_strings: bool = True) -> str:
+    def make_random_str(exclude_bytes: frozenset[str] = frozenset(), allow_empty_strings: bool = True) -> str:
         if allow_empty_strings:
             min_length = 0
         else:
@@ -147,7 +145,7 @@ class TestFormatting(TestCase):
         return ''.join(random.choices(list(STR_BYTES - exclude_bytes), k=random.randint(min_length, 128)))
 
     @staticmethod
-    def make_random_non_container(exclude_bytes: FrozenSet[str] = frozenset(), allow_empty_strings: bool = True):
+    def make_random_non_container(exclude_bytes: frozenset[str] = frozenset(), allow_empty_strings: bool = True):
         return random.choice([
             TestFormatting.make_random_int,
             TestFormatting.make_random_bool,
@@ -160,7 +158,7 @@ class TestFormatting(TestCase):
     @staticmethod
     def _make_random_obj(
             obj_stack,
-            force_container_type: Optional[Type[Union[dict, list]]] = None,
+            force_container_type: type[dict | list] | None = None,
             allow_non_container: bool = True,
             *args,
             **kwargs
@@ -190,7 +188,7 @@ class TestFormatting(TestCase):
             allow_empty_containers: bool = True,
             alternate_containers: bool = False,
             lists_can_contain_dicts: bool = True,
-            force_outer_container_type: Optional[Type[Union[dict, list]]] = None,
+            force_outer_container_type: type[dict | list] | None = None,
             allow_lists: bool = True,
             *args, **kwargs):
         obj_stack = []

--- a/test/test_graphtage.py
+++ b/test/test_graphtage.py
@@ -6,7 +6,6 @@ import graphtage
 import graphtage.json
 import graphtage.multiset
 import graphtage.tree
-
 from graphtage.printer import Printer
 
 from .timing import run_with_time_limit

--- a/test/test_levenshtein.py
+++ b/test/test_levenshtein.py
@@ -1,13 +1,11 @@
 import random
-from typing import List
 from unittest import TestCase
 
 from tqdm import trange
 
+from graphtage import EditDistance, string_edit_distance
 from graphtage.edits import Edit, Insert, Match, Remove
 from graphtage.levenshtein import levenshtein_distance
-from graphtage import EditDistance, string_edit_distance
-
 
 LETTERS: str = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 SMALL_ALPHABET: str = 'abcd'
@@ -21,7 +19,7 @@ class TestEditDistance(TestCase):
             str_from = ''.join(random.choices(LETTERS, k=str1_len))
             str_to = ''.join(random.choices(LETTERS, k=str2_len))
             distance: EditDistance = string_edit_distance(str_from, str_to)
-            edits: List[Edit] = list(distance.edits())
+            edits: list[Edit] = list(distance.edits())
             reconstructed_from = ''
             reconstructed_to = ''
             for edit in edits:
@@ -55,7 +53,7 @@ class TestEditDistance(TestCase):
                 else:
                     str_to += str_from[i]
             distance: EditDistance = string_edit_distance(str_from, str_to)
-            edits: List[Edit] = list(distance.edits())
+            edits: list[Edit] = list(distance.edits())
             num_edits = len(edits)
             if num_ground_truth_edits < num_edits:
                 print()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -59,3 +59,10 @@ class TestCommandLine(unittest.TestCase):
         to_path = self.write('two.json', '{this is not json\n')
         status, _ = self.run_graphtage(from_path, to_path)
         self.assertEqual(EXIT_ERROR, status)
+
+    def test_json5_parse_failure_is_an_error(self):
+        """A malformed JSON5 file used to raise TypeError from the error message's own format string."""
+        from_path = self.write('one.json5', '{a: 1}\n')
+        to_path = self.write('two.json5', '{a: 1,\n')
+        status, _ = self.run_graphtage(from_path, to_path)
+        self.assertEqual(EXIT_ERROR, status)

--- a/test/test_matching.py
+++ b/test/test_matching.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 import numpy as np
 from tqdm import tqdm, trange
 
-from graphtage.matching import get_dtype, min_weight_bipartite_matching, WeightedBipartiteMatcher
+from graphtage.matching import WeightedBipartiteMatcher, get_dtype, min_weight_bipartite_matching
 
 from .test_bounds import RandomDecreasingRange
 

--- a/test/test_matching.py
+++ b/test/test_matching.py
@@ -5,7 +5,14 @@ from unittest import TestCase
 import numpy as np
 from tqdm import tqdm, trange
 
-from graphtage.matching import WeightedBipartiteMatcher, get_dtype, min_weight_bipartite_matching
+from graphtage.bounds import Range
+from graphtage.matching import (
+    MatchingFromNode,
+    MatchingToNode,
+    WeightedBipartiteMatcher,
+    get_dtype,
+    min_weight_bipartite_matching,
+)
 
 from .test_bounds import RandomDecreasingRange
 
@@ -23,7 +30,8 @@ class TestWeightedBipartiteMatcher(TestCase):
             matcher = WeightedBipartiteMatcher(
                 from_nodes=from_nodes,
                 to_nodes=to_nodes,
-                get_edge=lambda n1, n2: edges[n1][n2]
+                # `edges` is bound as a default so the closure captures this iteration's matrix.
+                get_edge=lambda n1, n2, edges=edges: edges[n1][n2]
             )
             initial_bounds = matcher.bounds()
             prev_diff = initial_bounds.upper_bound - initial_bounds.lower_bound
@@ -57,7 +65,7 @@ class TestWeightedBipartiteMatcher(TestCase):
                 if (i, j) not in edges and random.random() < edge_probability
             })
 
-            def get_edge(f, t):
+            def get_edge(f, t, edges=edges):
                 if (f, t) in edges:
                     return edges[(f, t)]
                 else:
@@ -77,3 +85,36 @@ class TestWeightedBipartiteMatcher(TestCase):
         ):
             actual = get_dtype(min_range, max_range)
             self.assertEqual(np.dtype(expected), actual)
+
+
+class TestMatchingNode(TestCase):
+    """MatchingNode caches its edges lazily, and every accessor has to trigger that."""
+
+    class StubMatcher:
+        """The smallest thing MatchingNode.construct_edges needs from a matcher."""
+
+        def __init__(self):
+            self.from_nodes = []
+            self.to_nodes = []
+
+        @staticmethod
+        def get_edge(from_node, to_node):
+            return Range(0, 1)
+
+    def setUp(self):
+        self.matcher = TestMatchingNode.StubMatcher()
+        self.from_node = MatchingFromNode(self.matcher, 'f')
+        self.to_node = MatchingToNode(self.matcher, 't')
+        self.matcher.from_nodes.append(self.from_node)
+        self.matcher.to_nodes.append(self.to_node)
+
+    def test_contains_populates_the_cache(self):
+        """__contains__ used to reference the `edges` method without calling it, leaving the cache empty."""
+        self.assertIn(self.to_node, self.from_node)
+
+    def test_getitem_populates_the_cache(self):
+        """__getitem__ had the same no-op, so it raised TypeError on a None cache."""
+        self.assertIsNotNone(self.from_node[self.to_node])
+
+    def test_edges_agrees_with_getitem(self):
+        self.assertEqual([self.from_node[self.to_node]], list(self.from_node.edges()))

--- a/test/test_printer.py
+++ b/test/test_printer.py
@@ -2,7 +2,6 @@ import subprocess
 import sys
 import tempfile
 from os.path import join
-from typing import List
 from unittest import TestCase
 
 FROM_JSON = '{"a": 1, "b": [1, 2, 3]}'
@@ -19,7 +18,7 @@ def run_graphtage(*args: str) -> bytes:
         for path, contents in ((from_path, FROM_JSON), (to_path, TO_JSON)):
             with open(path, "w") as f:
                 f.write(contents)
-        command: List[str] = [sys.executable, "-m", "graphtage", "--no-status"]
+        command: list[str] = [sys.executable, "-m", "graphtage", "--no-status"]
         command.extend(args)
         command.extend((from_path, to_path))
         result = subprocess.run(command, capture_output=True)

--- a/test/test_progress.py
+++ b/test/test_progress.py
@@ -4,7 +4,6 @@ import sys
 import tempfile
 from io import StringIO
 from os.path import join
-from typing import List, Tuple
 from unittest import TestCase
 
 import graphtage.json
@@ -19,7 +18,7 @@ TO_OBJ = {"a": 2, "b": [1, 2, 4], "c": {"d": "goodbye world"}}
 PROGRESS_BAR = b"Diffing:"
 
 
-def run_graphtage(*args: str) -> Tuple[bytes, bytes]:
+def run_graphtage(*args: str) -> tuple[bytes, bytes]:
     """Runs the command line in a subprocess and returns what it wrote to stdout and to stderr.
 
     The subprocess matters: the modules that draw the progress bars resolve the default printer while they are being
@@ -29,17 +28,17 @@ def run_graphtage(*args: str) -> Tuple[bytes, bytes]:
         *args: Options to pass before the two file operands.
 
     Returns:
-        Tuple[bytes, bytes]: The bytes written to stdout and to stderr.
+        tuple[bytes, bytes]: The bytes written to stdout and to stderr.
 
     """
     with tempfile.TemporaryDirectory() as tmpdir:
-        paths: List[str] = []
+        paths: list[str] = []
         for name, obj in (("from.json", FROM_OBJ), ("to.json", TO_OBJ)):
             path = join(tmpdir, name)
             with open(path, "w") as f:
                 f.write(json.dumps(obj))
             paths.append(path)
-        command: List[str] = [sys.executable, "-m", "graphtage"]
+        command: list[str] = [sys.executable, "-m", "graphtage"]
         command.extend(args)
         command.extend(paths)
         result = subprocess.run(command, capture_output=True)

--- a/test/test_pydiff.py
+++ b/test/test_pydiff.py
@@ -3,7 +3,7 @@ import dataclasses
 from unittest import TestCase
 
 import graphtage
-from graphtage.pydiff import ast_to_tree, build_tree, print_diff, PyDiffFormatter
+from graphtage.pydiff import PyDiffFormatter, ast_to_tree, build_tree, print_diff
 
 from .timing import run_with_time_limit
 

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from tqdm import trange
 
 from graphtage.search import IterativeTighteningSearch
+
 from .test_bounds import RandomDecreasingRange
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 
 from graphtage.json import build_tree
 from graphtage.sequences import SequenceNode
-from graphtage.utils import HashableCounter, largest, smallest, SparseMatrix
+from graphtage.utils import HashableCounter, SparseMatrix, largest, smallest
 
 from .timing import run_with_time_limit
 

--- a/test/test_xml.py
+++ b/test/test_xml.py
@@ -1,6 +1,5 @@
 import unittest
 
-
 from graphtage.utils import Tempfile
 from graphtage.xml import XML
 

--- a/test/timing.py
+++ b/test/timing.py
@@ -1,5 +1,5 @@
-import threading
 import _thread
+import threading
 from contextlib import contextmanager
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -27,62 +27,12 @@ wheels = [
 ]
 
 [[package]]
-name = "backports-tarfile"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
-]
-
-[[package]]
-name = "cffi"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
-    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
-    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
-    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
-    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
-    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
-    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
-    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
-    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
-    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
-    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
-    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
-    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
-    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
 ]
 
 [[package]]
@@ -184,49 +134,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cryptography"
-version = "50.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
-    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
-    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
-    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
-    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/67/91eb047e69c5e845f2f14b8a2e4a1aab0f283cb885531e9e22c8adb176bc/cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc", size = 4700648, upload-time = "2026-07-31T14:24:00.702Z" },
-    { url = "https://files.pythonhosted.org/packages/30/82/85f0f7425c856b9f96459411eb12e74ef72df9caf6f8f15bf23a33ff131f/cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f", size = 4682442, upload-time = "2026-07-31T14:24:02.538Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/28/b555a365adff1cca2fbe7b9e487d68a40de6bc67ff2cb587473eb43de0e7/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3", size = 4707596, upload-time = "2026-07-31T14:24:04.394Z" },
-    { url = "https://files.pythonhosted.org/packages/38/14/6120e5bd7c5aa022ad15424ba4d5c5269d0d9448ed4d55e492ea91e3c1c4/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037", size = 4717113, upload-time = "2026-07-31T14:24:08.349Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/71/190bf38c3ee2e0f8efc9860ae100c9df4169742eef274b91e7aa1cb133b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f", size = 4338580, upload-time = "2026-07-31T14:24:10.227Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/63/504ccfbbe61fd8aa983f7f146399cdf034c72c2fc55f5b2dfdcdcdb20c99/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11", size = 4707038, upload-time = "2026-07-31T14:24:12.169Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/45/8aae2972c520145377ea3559a605a899bebe227bf070b33cdb445929a9b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c", size = 4716439, upload-time = "2026-07-31T14:24:16.415Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/20/4fe50b619a48c2525cc46e2dbc1ac490708d704be5d467bdaac6dc955682/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c", size = 4837383, upload-time = "2026-07-31T14:24:18.553Z" },
-    { url = "https://files.pythonhosted.org/packages/92/91/3a31366e183343d3703f8995c095f5734676bd6938118047e50fcf279eb4/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95", size = 4985772, upload-time = "2026-07-31T14:24:20.385Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
-    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
-    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
-    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
-    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
-    { url = "https://files.pythonhosted.org/packages/01/b6/0b9e125e90f3d2dcf599a218a899cda7326a3158cfa258723f0b398b08f6/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:8eb5e1172eb569ea8a872796576e6a67c276351728b6455d5beb01242b027c6a", size = 4692441, upload-time = "2026-07-31T14:24:53.743Z" },
-    { url = "https://files.pythonhosted.org/packages/53/c9/a5151588710785a96d7bc4de27d4cd62f263bbbcb203cfe29df537eb6505/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:910d11e1a385c654bf738bf3e6b8e6ed5de0f5610fcae2be9e5b398d8081d20e", size = 4699810, upload-time = "2026-07-31T14:24:55.746Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/1a/15b92b25eb6ce3089cd49377ae990a0f3ad485a510f968aed1f19dbdcdf2/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:62598a8a57f815db4c6259a4e97d857dab56697e7de8e8ab02352ab74da1995d", size = 4691924, upload-time = "2026-07-31T14:24:58.082Z" },
-    { url = "https://files.pythonhosted.org/packages/62/15/219075012ab13e8905f3cd572204f4acb4b111df787104346b9bc0cea789/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:07479a1cb08219ab719147e742e76090c9c773321959bb94946fffdd397a6437", size = 4699593, upload-time = "2026-07-31T14:24:59.951Z" },
-]
-
-[[package]]
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -284,7 +191,6 @@ dev = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-rtd-theme" },
-    { name = "twine" },
 ]
 
 [package.metadata]
@@ -292,32 +198,19 @@ requires-dist = [
     { name = "colorama" },
     { name = "fickling", specifier = ">=0.1.3" },
     { name = "intervaltree" },
-    { name = "json5", specifier = "==0.9.5" },
-    { name = "numpy", specifier = ">=1.19.4" },
+    { name = "json5", specifier = ">=0.9.5" },
+    { name = "numpy", specifier = ">=1.26" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pyyaml" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.0,<1.0" },
-    { name = "scipy", specifier = ">=1.4.0" },
+    { name = "scipy", specifier = ">=1.11" },
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "sphinx-rtd-theme", marker = "extra == 'dev'", specifier = "==3.0.2" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "tqdm" },
-    { name = "twine", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 provides-extras = ["dev"]
-
-[[package]]
-name = "id"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/22/11/102da08f88412d875fa2f1a9a469ff7ad4c874b0ca6fed0048fe385bdb3d/id-1.5.0.tar.gz", hash = "sha256:292cb8a49eacbbdbce97244f47a97b4c62540169c976552e497fd57df0734c1d", size = 15237, upload-time = "2024-12-04T19:53:05.575Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/cb/18326d2d89ad3b0dd143da971e77afd1e6ca6674f1b1c3df4b6bec6279fc/id-1.5.0-py3-none-any.whl", hash = "sha256:f1434e1cef91f2cbb8a4ec64663d5a23b9ed43ef44c4c957d02583d61714c658", size = 13611, upload-time = "2024-12-04T19:53:03.02Z" },
-]
 
 [[package]]
 name = "idna"
@@ -335,18 +228,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a", size = 1280026, upload-time = "2022-07-01T12:21:05.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b", size = 8769, upload-time = "2022-07-01T12:21:02.467Z" },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
 ]
 
 [[package]]
@@ -371,51 +252,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jaraco-classes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
-]
-
-[[package]]
-name = "jaraco-context"
-version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/9c/a788f5bb29c61e456b8ee52ce76dbdd32fd72cd73dd67bc95f42c7a8d13c/jaraco_context-6.1.0.tar.gz", hash = "sha256:129a341b0a85a7db7879e22acd66902fda67882db771754574338898b2d5d86f", size = 15850, upload-time = "2026-01-13T02:53:53.847Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/48/aa685dbf1024c7bd82bede569e3a85f82c32fd3d79ba5fea578f0159571a/jaraco_context-6.1.0-py3-none-any.whl", hash = "sha256:a43b5ed85815223d0d3cfdb6d7ca0d2bc8946f28f30b6f3216bda070f68badda", size = 7065, upload-time = "2026-01-13T02:53:53.031Z" },
-]
-
-[[package]]
-name = "jaraco-functools"
-version = "4.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
-]
-
-[[package]]
-name = "jeepney"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
-]
-
-[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -429,41 +265,11 @@ wheels = [
 
 [[package]]
 name = "json5"
-version = "0.9.5"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/b4/d09c00cb7bc88b17118be48f94d4b8d0ce7b572690625ca2b5477e05ce0e/json5-0.9.5.tar.gz", hash = "sha256:703cfee540790576b56a92e1c6aaa6c4b0d98971dc358ead83812aa4d06bdb96", size = 26464, upload-time = "2020-05-26T23:46:10.217Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71", size = 53278, upload-time = "2026-06-19T20:08:27.716Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/81/22bf51a5bc60dde18bb6164fd597f18ee683de8670e141364d9c432dd3cf/json5-0.9.5-py2.py3-none-any.whl", hash = "sha256:af1a1b9a2850c7f62c23fde18be4749b3599fd302f494eebf957e2ada6b9e42c", size = 17818, upload-time = "2020-05-26T23:46:08.743Z" },
-]
-
-[[package]]
-name = "keyring"
-version = "25.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
-    { name = "jaraco-classes" },
-    { name = "jaraco-context" },
-    { name = "jaraco-functools" },
-    { name = "jeepney", marker = "sys_platform == 'linux'" },
-    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
-    { name = "secretstorage", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
-]
-
-[[package]]
-name = "markdown-it-py"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618", size = 36570, upload-time = "2026-06-19T20:08:26.748Z" },
 ]
 
 [[package]]
@@ -549,57 +355,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "more-itertools"
-version = "10.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
-]
-
-[[package]]
-name = "nh3"
-version = "0.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/a5/34c26015d3a434409f4d2a1cd8821a06c05238703f49283ffeb937bef093/nh3-0.3.2.tar.gz", hash = "sha256:f394759a06df8b685a4ebfb1874fb67a9cbfd58c64fc5ed587a663c0e63ec376", size = 19288, upload-time = "2025-10-30T11:17:45.948Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/01/a1eda067c0ba823e5e2bb033864ae4854549e49fb6f3407d2da949106bfb/nh3-0.3.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d18957a90806d943d141cc5e4a0fefa1d77cf0d7a156878bf9a66eed52c9cc7d", size = 1419839, upload-time = "2025-10-30T11:17:09.956Z" },
-    { url = "https://files.pythonhosted.org/packages/30/57/07826ff65d59e7e9cc789ef1dc405f660cabd7458a1864ab58aefa17411b/nh3-0.3.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45c953e57028c31d473d6b648552d9cab1efe20a42ad139d78e11d8f42a36130", size = 791183, upload-time = "2025-10-30T11:17:11.99Z" },
-    { url = "https://files.pythonhosted.org/packages/af/2f/e8a86f861ad83f3bb5455f596d5c802e34fcdb8c53a489083a70fd301333/nh3-0.3.2-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c9850041b77a9147d6bbd6dbbf13eeec7009eb60b44e83f07fcb2910075bf9b", size = 829127, upload-time = "2025-10-30T11:17:13.192Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/97/77aef4daf0479754e8e90c7f8f48f3b7b8725a3b8c0df45f2258017a6895/nh3-0.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:403c11563e50b915d0efdb622866d1d9e4506bce590ef7da57789bf71dd148b5", size = 997131, upload-time = "2025-10-30T11:17:14.677Z" },
-    { url = "https://files.pythonhosted.org/packages/41/ee/fd8140e4df9d52143e89951dd0d797f5546004c6043285289fbbe3112293/nh3-0.3.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0dca4365db62b2d71ff1620ee4f800c4729849906c5dd504ee1a7b2389558e31", size = 1068783, upload-time = "2025-10-30T11:17:15.861Z" },
-    { url = "https://files.pythonhosted.org/packages/87/64/bdd9631779e2d588b08391f7555828f352e7f6427889daf2fa424bfc90c9/nh3-0.3.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0fe7ee035dd7b2290715baf29cb27167dddd2ff70ea7d052c958dbd80d323c99", size = 994732, upload-time = "2025-10-30T11:17:17.155Z" },
-    { url = "https://files.pythonhosted.org/packages/79/66/90190033654f1f28ca98e3d76b8be1194505583f9426b0dcde782a3970a2/nh3-0.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a40202fd58e49129764f025bbaae77028e420f1d5b3c8e6f6fd3a6490d513868", size = 975997, upload-time = "2025-10-30T11:17:18.77Z" },
-    { url = "https://files.pythonhosted.org/packages/34/30/ebf8e2e8d71fdb5a5d5d8836207177aed1682df819cbde7f42f16898946c/nh3-0.3.2-cp314-cp314t-win32.whl", hash = "sha256:1f9ba555a797dbdcd844b89523f29cdc90973d8bd2e836ea6b962cf567cadd93", size = 583364, upload-time = "2025-10-30T11:17:20.286Z" },
-    { url = "https://files.pythonhosted.org/packages/94/ae/95c52b5a75da429f11ca8902c2128f64daafdc77758d370e4cc310ecda55/nh3-0.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:dce4248edc427c9b79261f3e6e2b3ecbdd9b88c267012168b4a7b3fc6fd41d13", size = 589982, upload-time = "2025-10-30T11:17:21.384Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/bd/c7d862a4381b95f2469704de32c0ad419def0f4a84b7a138a79532238114/nh3-0.3.2-cp314-cp314t-win_arm64.whl", hash = "sha256:019ecbd007536b67fdf76fab411b648fb64e2257ca3262ec80c3425c24028c80", size = 577126, upload-time = "2025-10-30T11:17:22.755Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/3e/f5a5cc2885c24be13e9b937441bd16a012ac34a657fe05e58927e8af8b7a/nh3-0.3.2-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7064ccf5ace75825bd7bf57859daaaf16ed28660c1c6b306b649a9eda4b54b1e", size = 1431980, upload-time = "2025-10-30T11:17:25.457Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/f7/529a99324d7ef055de88b690858f4189379708abae92ace799365a797b7f/nh3-0.3.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8745454cdd28bbbc90861b80a0111a195b0e3961b9fa2e672be89eb199fa5d8", size = 820805, upload-time = "2025-10-30T11:17:26.98Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/62/19b7c50ccd1fa7d0764822d2cea8f2a320f2fd77474c7a1805cb22cf69b0/nh3-0.3.2-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72d67c25a84579f4a432c065e8b4274e53b7cf1df8f792cf846abfe2c3090866", size = 803527, upload-time = "2025-10-30T11:17:28.284Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/ca/f022273bab5440abff6302731a49410c5ef66b1a9502ba3fbb2df998d9ff/nh3-0.3.2-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:13398e676a14d6233f372c75f52d5ae74f98210172991f7a3142a736bd92b131", size = 1051674, upload-time = "2025-10-30T11:17:29.909Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f7/5728e3b32a11daf5bd21cf71d91c463f74305938bc3eb9e0ac1ce141646e/nh3-0.3.2-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:03d617e5c8aa7331bd2659c654e021caf9bba704b109e7b2b28b039a00949fe5", size = 1004737, upload-time = "2025-10-30T11:17:31.205Z" },
-    { url = "https://files.pythonhosted.org/packages/53/7f/f17e0dba0a99cee29e6cee6d4d52340ef9cb1f8a06946d3a01eb7ec2fb01/nh3-0.3.2-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2f55c4d2d5a207e74eefe4d828067bbb01300e06e2a7436142f915c5928de07", size = 911745, upload-time = "2025-10-30T11:17:32.945Z" },
-    { url = "https://files.pythonhosted.org/packages/42/0f/c76bf3dba22c73c38e9b1113b017cf163f7696f50e003404ec5ecdb1e8a6/nh3-0.3.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb18403f02b655a1bbe4e3a4696c2ae1d6ae8f5991f7cacb684b1ae27e6c9f7", size = 797184, upload-time = "2025-10-30T11:17:34.226Z" },
-    { url = "https://files.pythonhosted.org/packages/08/a1/73d8250f888fb0ddf1b119b139c382f8903d8bb0c5bd1f64afc7e38dad1d/nh3-0.3.2-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6d66f41672eb4060cf87c037f760bdbc6847852ca9ef8e9c5a5da18f090abf87", size = 838556, upload-time = "2025-10-30T11:17:35.875Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/09/deb57f1fb656a7a5192497f4a287b0ade5a2ff6b5d5de4736d13ef6d2c1f/nh3-0.3.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f97f8b25cb2681d25e2338148159447e4d689aafdccfcf19e61ff7db3905768a", size = 1006695, upload-time = "2025-10-30T11:17:37.071Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/61/8f4d41c4ccdac30e4b1a4fa7be4b0f9914d8314a5058472f84c8e101a418/nh3-0.3.2-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:2ab70e8c6c7d2ce953d2a58102eefa90c2d0a5ed7aa40c7e29a487bc5e613131", size = 1075471, upload-time = "2025-10-30T11:17:38.225Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c6/966aec0cb4705e69f6c3580422c239205d5d4d0e50fac380b21e87b6cf1b/nh3-0.3.2-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:1710f3901cd6440ca92494ba2eb6dc260f829fa8d9196b659fa10de825610ce0", size = 1002439, upload-time = "2025-10-30T11:17:39.553Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/c8/97a2d5f7a314cce2c5c49f30c6f161b7f3617960ade4bfc2fd1ee092cb20/nh3-0.3.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:91e9b001101fb4500a2aafe3e7c92928d85242d38bf5ac0aba0b7480da0a4cd6", size = 987439, upload-time = "2025-10-30T11:17:40.81Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/95/2d6fc6461687d7a171f087995247dec33e8749a562bfadd85fb5dbf37a11/nh3-0.3.2-cp38-abi3-win32.whl", hash = "sha256:169db03df90da63286e0560ea0efa9b6f3b59844a9735514a1d47e6bb2c8c61b", size = 589826, upload-time = "2025-10-30T11:17:42.239Z" },
-    { url = "https://files.pythonhosted.org/packages/64/9a/1a1c154f10a575d20dd634e5697805e589bbdb7673a0ad00e8da90044ba7/nh3-0.3.2-cp38-abi3-win_amd64.whl", hash = "sha256:562da3dca7a17f9077593214a9781a94b8d76de4f158f8c895e62f09573945fe", size = 596406, upload-time = "2025-10-30T11:17:43.773Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/7e/a96255f63b7aef032cbee8fc4d6e37def72e3aaedc1f72759235e8f13cb1/nh3-0.3.2-cp38-abi3-win_arm64.whl", hash = "sha256:cf5964d54edd405e68583114a7cba929468bcd7db5e676ae38ee954de1cfc104", size = 584162, upload-time = "2025-10-30T11:17:44.96Z" },
 ]
 
 [[package]]
@@ -768,15 +523,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycparser"
-version = "2.23"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -801,15 +547,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
-]
-
-[[package]]
-name = "pywin32-ctypes"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -877,20 +614,6 @@ wheels = [
 ]
 
 [[package]]
-name = "readme-renderer"
-version = "44.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docutils" },
-    { name = "nh3" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1", size = 32056, upload-time = "2024-07-08T15:00:57.805Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310, upload-time = "2024-07-08T15:00:56.577Z" },
-]
-
-[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -903,40 +626,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
-]
-
-[[package]]
-name = "requests-toolbelt"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
-]
-
-[[package]]
-name = "rfc3986"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
-]
-
-[[package]]
-name = "rich"
-version = "14.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
 ]
 
 [[package]]
@@ -1116,19 +805,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/5e/e565bd73991d42023eb82bb99e51c5b3d9e2c588ca9d4b3e2cc1d3ca62a6/scipy-1.17.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9eb55bb97d00f8b7ab95cb64f873eb0bf54d9446264d9f3609130381233483f", size = 37457743, upload-time = "2026-01-10T21:30:34.819Z" },
     { url = "https://files.pythonhosted.org/packages/58/a8/a66a75c3d8f1fb2b83f66007d6455a06a6f6cf5618c3dc35bc9b69dd096e/scipy-1.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1ff269abf702f6c7e67a4b7aad981d42871a11b9dd83c58d2d2ea624efbd1088", size = 37098574, upload-time = "2026-01-10T21:30:40.782Z" },
     { url = "https://files.pythonhosted.org/packages/56/a5/df8f46ef7da168f1bc52cd86e09a9de5c6f19cc1da04454d51b7d4f43408/scipy-1.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:031121914e295d9791319a1875444d55079885bbae5bdc9c5e0f2ee5f09d34ff", size = 25246266, upload-time = "2026-01-10T21:30:45.923Z" },
-]
-
-[[package]]
-name = "secretstorage"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]
@@ -1378,26 +1054,6 @@ wheels = [
 ]
 
 [[package]]
-name = "twine"
-version = "6.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "id" },
-    { name = "keyring", marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'" },
-    { name = "packaging" },
-    { name = "readme-renderer" },
-    { name = "requests" },
-    { name = "requests-toolbelt" },
-    { name = "rfc3986" },
-    { name = "rich" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1413,13 +1069,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ dependencies = [
     { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "toml" },
     { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 
 [package.optional-dependencies]
@@ -296,14 +296,14 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.19.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pyyaml" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.0,<1.0" },
     { name = "scipy", specifier = ">=1.4.0" },
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "sphinx-rtd-theme", marker = "extra == 'dev'", specifier = "==3.0.2" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "tqdm" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "typing-extensions", specifier = ">=3.7.4.3" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 provides-extras = ["dev"]
 
@@ -962,28 +962,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.14.13"
+version = "0.16.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/0a/1914efb7903174b381ee2ffeebb4253e729de57f114e63595114c8ca451f/ruff-0.14.13.tar.gz", hash = "sha256:83cd6c0763190784b99650a20fec7633c59f6ebe41c5cc9d45ee42749563ad47", size = 6059504, upload-time = "2026-01-15T20:15:16.918Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/85/c8e12473c93018f92d19dd988a294202e1c27426c47ec4de53ffb847b8d8/ruff-0.16.5.tar.gz", hash = "sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b", size = 4912003, upload-time = "2026-08-27T16:34:18.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/ae/0deefbc65ca74b0ab1fd3917f94dc3b398233346a74b8bbb0a916a1a6bf6/ruff-0.14.13-py3-none-linux_armv6l.whl", hash = "sha256:76f62c62cd37c276cb03a275b198c7c15bd1d60c989f944db08a8c1c2dbec18b", size = 13062418, upload-time = "2026-01-15T20:14:50.779Z" },
-    { url = "https://files.pythonhosted.org/packages/47/df/5916604faa530a97a3c154c62a81cb6b735c0cb05d1e26d5ad0f0c8ac48a/ruff-0.14.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:914a8023ece0528d5cc33f5a684f5f38199bbb566a04815c2c211d8f40b5d0ed", size = 13442344, upload-time = "2026-01-15T20:15:07.94Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/f3/e0e694dd69163c3a1671e102aa574a50357536f18a33375050334d5cd517/ruff-0.14.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d24899478c35ebfa730597a4a775d430ad0d5631b8647a3ab368c29b7e7bd063", size = 12354720, upload-time = "2026-01-15T20:15:09.854Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/e8/67f5fcbbaee25e8fc3b56cc33e9892eca7ffe09f773c8e5907757a7e3bdb/ruff-0.14.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9aaf3870f14d925bbaf18b8a2347ee0ae7d95a2e490e4d4aea6813ed15ebc80e", size = 12774493, upload-time = "2026-01-15T20:15:20.908Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ce/d2e9cb510870b52a9565d885c0d7668cc050e30fa2c8ac3fb1fda15c083d/ruff-0.14.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac5b7f63dd3b27cc811850f5ffd8fff845b00ad70e60b043aabf8d6ecc304e09", size = 12815174, upload-time = "2026-01-15T20:15:05.74Z" },
-    { url = "https://files.pythonhosted.org/packages/88/00/c38e5da58beebcf4fa32d0ddd993b63dfacefd02ab7922614231330845bf/ruff-0.14.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78d2b1097750d90ba82ce4ba676e85230a0ed694178ca5e61aa9b459970b3eb9", size = 13680909, upload-time = "2026-01-15T20:15:14.537Z" },
-    { url = "https://files.pythonhosted.org/packages/61/61/cd37c9dd5bd0a3099ba79b2a5899ad417d8f3b04038810b0501a80814fd7/ruff-0.14.13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:7d0bf87705acbbcb8d4c24b2d77fbb73d40210a95c3903b443cd9e30824a5032", size = 15144215, upload-time = "2026-01-15T20:15:22.886Z" },
-    { url = "https://files.pythonhosted.org/packages/56/8a/85502d7edbf98c2df7b8876f316c0157359165e16cdf98507c65c8d07d3d/ruff-0.14.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3eb5da8e2c9e9f13431032fdcbe7681de9ceda5835efee3269417c13f1fed5c", size = 14706067, upload-time = "2026-01-15T20:14:48.271Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/2f/de0df127feb2ee8c1e54354dc1179b4a23798f0866019528c938ba439aca/ruff-0.14.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:642442b42957093811cd8d2140dfadd19c7417030a7a68cf8d51fcdd5f217427", size = 14133916, upload-time = "2026-01-15T20:14:57.357Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/77/9b99686bb9fe07a757c82f6f95e555c7a47801a9305576a9c67e0a31d280/ruff-0.14.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4acdf009f32b46f6e8864af19cbf6841eaaed8638e65c8dac845aea0d703c841", size = 13859207, upload-time = "2026-01-15T20:14:55.111Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/46/2bdcb34a87a179a4d23022d818c1c236cb40e477faf0d7c9afb6813e5876/ruff-0.14.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:591a7f68860ea4e003917d19b5c4f5ac39ff558f162dc753a2c5de897fd5502c", size = 14043686, upload-time = "2026-01-15T20:14:52.841Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/a9/5c6a4f56a0512c691cf143371bcf60505ed0f0860f24a85da8bd123b2bf1/ruff-0.14.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:774c77e841cc6e046fc3e91623ce0903d1cd07e3a36b1a9fe79b81dab3de506b", size = 12663837, upload-time = "2026-01-15T20:15:18.921Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/bb/b920016ece7651fa7fcd335d9d199306665486694d4361547ccb19394c44/ruff-0.14.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:61f4e40077a1248436772bb6512db5fc4457fe4c49e7a94ea7c5088655dd21ae", size = 12805867, upload-time = "2026-01-15T20:14:59.272Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/b3/0bd909851e5696cd21e32a8fc25727e5f58f1934b3596975503e6e85415c/ruff-0.14.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6d02f1428357fae9e98ac7aa94b7e966fd24151088510d32cf6f902d6c09235e", size = 13208528, upload-time = "2026-01-15T20:15:03.732Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/3b/e2d94cb613f6bbd5155a75cbe072813756363eba46a3f2177a1fcd0cd670/ruff-0.14.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e399341472ce15237be0c0ae5fbceca4b04cd9bebab1a2b2c979e015455d8f0c", size = 13929242, upload-time = "2026-01-15T20:15:11.918Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c5/abd840d4132fd51a12f594934af5eba1d5d27298a6f5b5d6c3be45301caf/ruff-0.14.13-py3-none-win32.whl", hash = "sha256:ef720f529aec113968b45dfdb838ac8934e519711da53a0456038a0efecbd680", size = 12919024, upload-time = "2026-01-15T20:14:43.647Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/55/6384b0b8ce731b6e2ade2b5449bf07c0e4c31e8a2e68ea65b3bafadcecc5/ruff-0.14.13-py3-none-win_amd64.whl", hash = "sha256:6070bd026e409734b9257e03e3ef18c6e1a216f0435c6751d7a8ec69cb59abef", size = 14097887, upload-time = "2026-01-15T20:15:01.48Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/e1/7348090988095e4e39560cfc2f7555b1b2a7357deba19167b600fdf5215d/ruff-0.14.13-py3-none-win_arm64.whl", hash = "sha256:7ab819e14f1ad9fe39f246cfcc435880ef7a9390d81a2b6ac7e01039083dd247", size = 13080224, upload-time = "2026-01-15T20:14:45.853Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/b6/77c90a970fe2dae17a723acbd011043ea97c98d7deacccefdc4ba74ec512/ruff-0.16.5-py3-none-linux_armv6l.whl", hash = "sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b", size = 10011941, upload-time = "2026-08-27T16:33:41.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/46/6cf67cf6411885a1d6f7f6d801682f155536a85176d10b605e2ceffed8bd/ruff-0.16.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3", size = 10204049, upload-time = "2026-08-27T16:33:44.056Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fd/c8720ca7a090abf0c2fef4abe8a5ef6e5127ed15196d8886ff75a2b370e2/ruff-0.16.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb", size = 9809037, upload-time = "2026-08-27T16:33:46.257Z" },
+    { url = "https://files.pythonhosted.org/packages/43/45/a684caacdedaca180f52bacccc40bf0789d2c5a7c75f25324853e9eaedb5/ruff-0.16.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025", size = 9964129, upload-time = "2026-08-27T16:33:48.352Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/5d2bcdaca6b5b93d1b4dfc166cd2aebf7680143a1b38a28759df13a94d31/ruff-0.16.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9", size = 9821518, upload-time = "2026-08-27T16:33:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ff/011cce29accf9257d5974145b733fc653a37985ed6825413a3987cefbfe0/ruff-0.16.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7", size = 10534835, upload-time = "2026-08-27T16:33:52.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/5a/f0cf109bada9bba0e96c90c21c9f9251803f57225c32d293327a03c710d6/ruff-0.16.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde", size = 11252550, upload-time = "2026-08-27T16:33:54.521Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4d/1d481aaea2046c6a7ed7c291f9004c669cce3c087b6b376ed5b08271e3fe/ruff-0.16.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea", size = 10777949, upload-time = "2026-08-27T16:33:56.88Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/34/ee245ca55f64443233034b3d02b03236b19242004281247c079390b7facd/ruff-0.16.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105", size = 10311656, upload-time = "2026-08-27T16:33:59.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/c33a333e341c0a2b96c715b52d89a606f5a34cd4ac493cd9b8d0187186b8/ruff-0.16.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29", size = 10532125, upload-time = "2026-08-27T16:34:01.166Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/a64cef78b40192497bb98a27a8aa8f2c98ee9ee15bc97f7712d94ef32937/ruff-0.16.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf", size = 10097648, upload-time = "2026-08-27T16:34:03.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4e/4cdc9ed3c3e109d2f71e62572a37457298d7bc7501ec3138babb7ed32bbd/ruff-0.16.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91", size = 9829344, upload-time = "2026-08-27T16:34:05.134Z" },
+    { url = "https://files.pythonhosted.org/packages/39/4a/31ed35ce31729955fc583ee0d176d6e784c1290cb0b0a75cb2134c1ab72a/ruff-0.16.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a", size = 10277117, upload-time = "2026-08-27T16:34:07.425Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a0/60356d86687b4b666d593df213f4dc3041750d024cb7bf2cfa81cfd65c2e/ruff-0.16.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef", size = 10711653, upload-time = "2026-08-27T16:34:09.712Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/20/656d67f5b25ca9bda4e02b1de25867b2954e1d19e03648060f167ad0f4cc/ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26", size = 10034250, upload-time = "2026-08-27T16:34:11.8Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/42/ee8e68a207b9127fcde6c3d7e197def432f346cb1af159e1fa14ca0d1cdc/ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f", size = 10516714, upload-time = "2026-08-27T16:34:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e3/7df5a396e445b9ba49ce9a9437439a4d80042c61c0ade199abf8d16de1ac/ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e", size = 10391564, upload-time = "2026-08-27T16:34:16.064Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #140.

Commit `332edf6` raised the floor to Python 3.10 but deliberately left the resulting code churn out, so the configuration diff stayed reviewable. This is that follow-up, plus the things the floor change exposed along the way.

Ruff went from 736 findings to zero. The tree is now clean, and CI enforces that.

## Read this in order

The commits are meant to be reviewed one at a time. One of them is ~950 lines of mechanical annotation churn; the rest are small and hand-written.

| Commit | What to look at |
| --- | --- |
| Fix TypeError on the JSON5 parse-error path | A real bug, with a regression test |
| Move ruff settings into the lint section | Config only |
| Import Protocol from typing instead of typing_extensions | Small, but see the fickling note below |
| Remove the Python 3.6 compatibility branches | Hand-written, highest risk |
| Adopt PEP 585 and PEP 604 annotations | The big mechanical one. Skimmable |
| Drop the typing.Counter base from HashableCounter | One line, MRO-sensitive |
| Clear the remaining ruff findings | Four non-mechanical changes, called out in the message |
| Modernize dependency specifiers | json5 unpinned, numpy/scipy floors, twine dropped |
| Gate CI on ruff and repair the release workflow | The release workflow was broken |
| Correct the docs config and developer guidelines | Sphinx deprecations, CLAUDE.md |
| Match docstring return types to the rewritten signatures | Prose only |

## Bugs found along the way

**`graphtage/json.py` crashed on every malformed JSON5 file.** The error message used `{ve:!s}`, a format spec of `!s` rather than the `!s` conversion, so it raised `TypeError: unsupported format string passed to ValueError.__format__` instead of reporting the parse error.

**`MatchingNode.__getitem__` and `__contains__` never populated their cache.** Both did `self.edges` without calling it, so the statement was a no-op and the next line dereferenced `None`. Only the partial Karp78 implementation constructs these nodes, which is why nothing caught it.

**The release workflow could not have produced a release.** It still ran `python setup.py sdist bdist_wheel`, and `setup.py` was deleted in the hatchling migration.

**`publish_docs.yml` used `::set-env`,** which GitHub disabled in November 2020 for CVE-2020-15228, and which only still worked because the workflow opted back in with `ACTIONS_ALLOW_UNSECURE_COMMANDS`.

## Two things a blind `ruff --fix` gets wrong

Worth knowing about, because they both break the package at import time and neither is obvious:

- `matching.py`'s `Matching` used `typing.Set[Edge[T]]` as a base. UP006's *safe* fix rewrites that to `set[Edge[T]]`, which is an unsatisfiable MRO: `typing.Set.__mro_entries__` relocates an explicit `Generic[T]` to the end of the base list, and `types.GenericAlias` does not. Writing `Generic[T]` last resolves it and reproduces the current MRO exactly.
- `graphtage/__init__.py` has a load-bearing import order. isort hoists the plain submodule imports above the star imports, and `graphtage/ast.py` does `from . import DictNode, ...`, so the package no longer imports. `UP` and `F401` alone produce a zero-line diff there, so the fix is a per-file ignore.

## typing_extensions is not fully gone

Dropping it outright breaks Python 3.11. `fickling`'s `fickle.py` imports `typing_extensions.Buffer` when `sys.version_info < (3, 12)` but does not declare the dependency, and graphtage's own requirement was masking that. Nothing else installs it on 3.11: `cryptography` pulls it in only below 3.11, and it is in the standard library from 3.12. So a narrowed `typing_extensions; python_version < '3.12'` stays, with a comment saying whose requirement it actually is. **This is worth reporting upstream.**

## Behavior changes

**Top-level star exports shrink.** No module declares `__all__`, so `from .tree import *` currently re-exports whatever `tree.py` imported. `graphtage.List`, `graphtage.Dict`, `graphtage.Optional`, `graphtage.Union`, `graphtage.Tuple`, `graphtage.Type`, `graphtage.Iterable`, `graphtage.Sized`, `graphtage.Callable` and `graphtage.Sequence` all resolve today and will not after this. `graphtage.formatter.GenericMeta`, an alias for `abc.ABCMeta`, also goes.

**One MRO detail changes.** `typing.Sized` is a generic alias, so using it as a base injects `Generic`; `collections.abc.Sized` does not. `ContainerNode` and its subclasses drop a vestigial `Generic` base. Nothing depends on it: `ContainerNode` has no type parameters either way, is not subscriptable in either form, and `isinstance` is unaffected. Every genuinely generic class declares `Generic[T]` explicitly and is unchanged.

**Five `zip()` calls became `strict=True`,** which turns a silent truncation into an error where the operands are equal by construction. The three deliberately ragged ones got `strict=False` and a note.

## Deliberately not in scope

`py.typed` and a type checker. The package has extensive annotations that are invisible downstream, and two unexplained `# type: ignore` comments. But shipping `py.typed` advertises a guarantee nothing verifies, and getting this much generic code through a strict checker is its own project. Worth a follow-up issue.

## Verification

- Full suite on 3.10, 3.11, 3.12, 3.13 and 3.14: 140 passed on each, up from 137. Running on 3.10 and 3.11 specifically matters, because `typing_extensions.Protocol` and `typing.Protocol` differ there and are the same object from 3.12 on.
- `ruff check graphtage test docs bindist` clean; `uv lock --check` clean; `actionlint` clean; `zizmor` reports no actionable findings.
- Docs build on 3.10 and 3.14, down from four Sphinx warnings to two pre-existing autodoc duplicates.
- An MRO fingerprint of all 183 classes was captured before the sweep and diffed after every commit; the only delta is the `ContainerNode` one described above.
- `uv build`, then installing the wheel and running the CLI.
- CLI smoke tests: cross-format diff, HTML output, and the JSON5 error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa