### PR TITLE
Fix the documentation build warnings and gate CI on them

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build documentation
         working-directory: graphtage
-        run: uv run --frozen --extra dev make -C docs html
+        run: uv run --frozen --extra dev make -C docs html SPHINXOPTS="-W --keep-going"
 
       - name: Checkout gh-pages branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Test building documentation
-        run: uv run --frozen --extra dev make -C docs html
+        run: uv run --frozen --extra dev make -C docs html SPHINXOPTS="-W --keep-going"
 
       - name: Test with pytest
         run: uv run --frozen --extra dev pytest

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,5 +1,10 @@
 {%- extends "!layout.html" %}
 
+{# The published site puts each release in its own directory, so a sibling version is one level up
+   from the current page. `pathto('', 1)` is the relative path back to the root of this version. #}
+{%- set this_version_root = pathto('', 1) %}
+{%- set version_root = ('' if this_version_root == './' else this_version_root) ~ '../' %}
+
 {% block footer %}
   {% if not READTHEDOCS %}
     <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
@@ -11,27 +16,21 @@
       <div class="rst-other-versions">
         <dl>
           <dt>{{ _('Versions') }}</dt>
-          {% if test_versions %}
-            {% for version in test_versions %}
-            <dd><a href="#">{{ version }}</a></dd>
-            {% endfor %}
-          {% else %}
-            <dd><a href="/graphtage/latest">latest</a></dd>
-            <dd><a href="/graphtage/v0.3.1">0.3.1</a></dd>
-            <dd><a href="/graphtage/v0.3.0">0.3.0</a></dd>
-            <dd><a href="/graphtage/v0.2.9">0.2.9</a></dd>
-            <dd><a href="/graphtage/v0.2.8">0.2.8</a></dd>
-            <dd><a href="/graphtage/v0.2.7">0.2.7</a></dd>
-            <dd><a href="/graphtage/v0.2.6">0.2.6</a></dd>
-            <dd><a href="/graphtage/v0.2.5">0.2.5</a></dd>
-            <dd><a href="/graphtage/v0.2.4">0.2.4</a></dd>
-            <dd><a href="/graphtage/v0.2.3">0.2.3</a></dd>
-            <dd><a href="/graphtage/v0.2.2">0.2.2</a></dd>
-            <dd><a href="/graphtage/v0.2.1">0.2.1</a></dd>
-            <dd><a href="/graphtage/v0.2.0">0.2.0</a></dd>
-            <dd><a href="/graphtage/v0.1.1">0.1.1</a></dd>
-            <dd><a href="/graphtage/v0.1.0">0.1.0</a></dd>
-          {% endif %}
+          <dd><a href="{{ version_root }}latest/">latest</a></dd>
+          <dd><a href="{{ version_root }}v0.3.1/">0.3.1</a></dd>
+          <dd><a href="{{ version_root }}v0.3.0/">0.3.0</a></dd>
+          <dd><a href="{{ version_root }}v0.2.9/">0.2.9</a></dd>
+          <dd><a href="{{ version_root }}v0.2.8/">0.2.8</a></dd>
+          <dd><a href="{{ version_root }}v0.2.7/">0.2.7</a></dd>
+          <dd><a href="{{ version_root }}v0.2.6/">0.2.6</a></dd>
+          <dd><a href="{{ version_root }}v0.2.5/">0.2.5</a></dd>
+          <dd><a href="{{ version_root }}v0.2.4/">0.2.4</a></dd>
+          <dd><a href="{{ version_root }}v0.2.3/">0.2.3</a></dd>
+          <dd><a href="{{ version_root }}v0.2.2/">0.2.2</a></dd>
+          <dd><a href="{{ version_root }}v0.2.1/">0.2.1</a></dd>
+          <dd><a href="{{ version_root }}v0.2.0/">0.2.0</a></dd>
+          <dd><a href="{{ version_root }}v0.1.1/">0.1.1</a></dd>
+          <dd><a href="{{ version_root }}v0.1.0/">0.1.0</a></dd>
         </dl>
         <dl>
           <dt>{{ _('Source Code') }}</dt>

--- a/docs/build_api.py
+++ b/docs/build_api.py
@@ -10,6 +10,10 @@ sys.path = [ROOT_PATH, *sys.path]
 
 import graphtage  # noqa: E402  (imported only after ROOT_PATH is on sys.path)
 
+# graphtage/__init__.py deliberately omits `git`, because graphtage.git imports graphtage.__main__.
+# Import it here so that the module enumeration below gives it an API page.
+import graphtage.git  # noqa: E402
+
 MODULES = []
 
 
@@ -84,6 +88,8 @@ def process_module(module):
 
 
 for name, obj in inspect.getmembers(graphtage, inspect.ismodule):
+    if name.startswith('_'):
+        continue
     if obj.__name__.startswith('graphtage') and name not in ('graphtage', 'tree', 'edits'):
         MODULES.append(obj)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,6 @@ def setup(app):
     #app.connect('autodoc-process-docstring', docstring_callback)
 
 
-add_package_names = False
 # prefix each section label with the name of the document it is in, followed by a colon
 autosectionlabel_prefix_document = True
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}

--- a/graphtage/graphtage.py
+++ b/graphtage/graphtage.py
@@ -1059,7 +1059,7 @@ class BuildOptions:
         """If `True` and if `check_for_cycles` is also `True`, then ignore cycles in the input,
         preventing an infinite loop."""
         self.printer = printer
-        """A printer to use while building trees (default is :class:`graphtage.printer.NullPrinter`)"""
+        """A printer to use while building trees (default is :attr:`graphtage.printer.NULL_PRINTER`)"""
         for attr, value in kwargs.items():
             setattr(self, attr, value)
 

--- a/graphtage/json.py
+++ b/graphtage/json.py
@@ -1,7 +1,7 @@
 """A :class:`graphtage.Filetype` for parsing, diffing, and rendering `JSON files`_.
 
 .. _JSON files:
-    https://tools.ietf.org/html/std90
+    https://www.rfc-editor.org/info/std90/
 
 """
 

--- a/graphtage/matching.py
+++ b/graphtage/matching.py
@@ -24,7 +24,7 @@ Example:
 .. _the assignment problem: https://en.wikipedia.org/wiki/Assignment_problem
 .. [Karp78] `Richard M. Karp <https://en.wikipedia.org/wiki/Richard_M._Karp>`_. |karp78title|_. 1978. It is partially
     implemented in :class:`WeightedBipartiteMatcherPARTIAL_IMPLEMENTATION`.
-.. _karp78title: https://www2.eecs.berkeley.edu/Pubs/TechRpts/1978/ERL-m-78-67.pdf
+.. _karp78title: https://digitalassets.lib.berkeley.edu/techreports/ucb/text/ERL-m-78-67.pdf
 .. |karp78title| replace:: *An Algorithm to Solve the* :math:`m \\times n` *Assignment Problem in Expected Time*
     :math:`O(mn \\log n)`
 .. _scipy_linear_sum_assignment:

--- a/graphtage/printer.py
+++ b/graphtage/printer.py
@@ -12,6 +12,8 @@ Attributes:
     DEFAULT_PRINTER (Printer): A default :class:`Printer` instance printing to :attr:`sys.stdout`. Read it through
         :func:`get_default_printer` rather than importing the name, because :func:`set_default_printer` replaces it.
 
+    NULL_PRINTER (Printer): A :class:`Printer` instance that discards everything written to it.
+
 """
 
 import logging

--- a/graphtage/tree.py
+++ b/graphtage/tree.py
@@ -78,15 +78,7 @@ class GraphtageFormatter(FormatterType):
 
 @runtime_checkable
 class Edit(Bounded, Protocol):
-    """A protocol for defining an edit.
-
-    Attributes:
-        initial_bounds (Range): The initial bounds of this edit. Classes implementing this protocol can, for example,
-            set this by calling :meth:`self.bounds()<Edit.bounds>` during initialization.
-
-        from_node (TreeNode): The node that this edit transforms.
-
-    """
+    """A protocol for defining an edit."""
     initial_bounds: Range
     """The initial bounds of this edit.
 


### PR DESCRIPTION
Documentation build hygiene: get the Sphinx build to zero warnings, fix three
references that pointed at nothing, and gate CI on warnings so the build stays clean.

This is the first of three documentation pull requests. It touches only the source
docstrings, the Sphinx configuration, and the workflows; it makes no editorial changes
to the prose pages.

## Changes

**Remove the duplicated `Edit` attribute descriptions** (`graphtage/tree.py`)

`Edit` documented `initial_bounds` and `from_node` twice: once in a Google-style
`Attributes:` block, which Napoleon renders as `.. attribute::` directives, and once as
PEP 224 attribute docstrings, which autodoc emits under `:members:`. Sphinx reported both
pairs as duplicate object descriptions, which were the only two warnings in the build. The
attribute docstrings are the better source, because they carry the `:meth:` cross-reference
and take their type from the annotation, so the `Attributes:` block is gone and they stay.

**Point `BuildOptions.printer` at the real null printer** (`graphtage/graphtage.py`,
`graphtage/printer.py`)

The docstring referenced `graphtage.printer.NullPrinter`, a class that does not exist
anywhere in the package. The default value is the `NULL_PRINTER` instance in
`graphtage.printer`. That constant had no documentation entry, so referencing it by the
correct name would still not have resolved; it is now documented in the
`graphtage.printer` module docstring next to `DEFAULT_PRINTER`, which gives it a target.
This is the one file outside the set listed for this pull request, and it is a two-line
addition.

**Replace two stale URLs** (`graphtage/matching.py`, `graphtage/json.py`)

The Karp 1978 technical report link redirected to a 404 on the EECS site, and the JSON
standard link redirected away from `tools.ietf.org`. Both replacements return HTTP 200
under `sphinx-build -b linkcheck`.

**Remove the no-op `add_package_names` setting** (`docs/conf.py`)

Sphinx has no `add_package_names` option, and it ignores unknown names in `conf.py`, so
this line never had any effect. The comparable real option is `add_module_names`, which
controls whether generated API entries carry a fully qualified prefix. Setting it changes
the rendering of every generated page, so it is left unset here; see the follow-up note
at the end.

**Generate an API page for `graphtage.git`** (`docs/build_api.py`)

`graphtage.git` backs the `graphtage-git-diff` console script and gets about 88 lines in
the README, but it had no API page. `build_api.py` enumerates
`inspect.getmembers(graphtage, inspect.ismodule)`, and `graphtage/__init__.py` does not
import `git`, so the module was invisible to it. `build_api.py` now imports
`graphtage.git` itself. Adding it to `graphtage/__init__.py` instead would make every
`import graphtage` pull in `graphtage.__main__`, which `graphtage/git.py` imports, and set
up a double import of `__main__` under `python -m graphtage`, for a documentation-only
benefit. The same loop now skips private module names, so the transitive
`graphtage.__main__` import does not produce a page of its own.

**Make the version switcher links relative** (`docs/_templates/layout.html`)

The version links used root-absolute hrefs such as `/graphtage/v0.3.1`, which resolve only
on a host serving the site at `/graphtage/`; local builds and any other prefix got a 404.
The hrefs are now built from `pathto('', 1)`, so they point at a sibling directory of the
current version, matching the published `gh-pages/<version>/` layout. The template also
had an unreachable `{% if test_versions %}` branch: nothing in `docs/` defines
`test_versions`, and the loop inside it shadowed the outer `version` variable. The version
list contents are unchanged.

**Fail the docs build on Sphinx warnings** (both workflows)

Both workflows now pass `SPHINXOPTS="-W --keep-going"` to `make -C docs html`.
`--keep-going` reports every warning in one run instead of stopping at the first. Nitpick
mode (`-n`) is deliberately not enabled: it adds about 2100 warnings, almost all
unresolvable autodoc `TypeVar` references (`graphtage.T`, `graphtage.formatter.T`) and
`:const:`True/False/None`` in generated files.

## Verification

- `uv run --frozen --extra dev make -C docs clean && uv run --frozen --extra dev make -C docs html SPHINXOPTS="-W --keep-going"`: build succeeded, zero warnings.
- `uv run --frozen --extra dev sphinx-build -W --keep-going -E -b html docs docs/_build/html`: build succeeded, exit code 0.
- `docs/graphtage.git.rst` is generated and `graphtage.git` appears in the generated `docs/package.rst`. No `docs/graphtage.__main__.rst` is produced. Both files are gitignored build artifacts and are not committed.
- `uv run --frozen python -c "import graphtage, sys; print('graphtage.__main__' in sys.modules)"` prints `False`.
- `uv run --frozen --extra dev sphinx-build -b linkcheck docs /tmp/gt-linkcheck` reports both changed URLs as `ok`:
  - `(graphtage.matching: line 25) ok https://digitalassets.lib.berkeley.edu/techreports/ucb/text/ERL-m-78-67.pdf`
  - `(  graphtage.json: line 1) ok https://www.rfc-editor.org/info/std90/`
- The rendered version links were checked against a copy of the build placed in a simulated `gh-pages` tree (`site/latest/` beside `site/v0.3.1/`). They render as `../v0.3.1/` and resolve to the sibling directory. All 41 output pages sit at the top level of the version directory today; the `pathto('', 1)` prefix also produces the correct `../../v0.3.1/` if a page is ever nested one level deeper.
- `uv run --frozen ruff check graphtage test docs bindist`: all checks passed.
- `uv run --frozen pytest -q`: 140 passed.

## Possible follow-up

`add_module_names = False` is the real Sphinx option that the deleted line appears to have
been reaching for. Setting it would drop the module prefix from generated API entries,
which changes the rendering of every generated page, so it belongs in its own change where
the result can be reviewed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa
