### PR TITLE
Fix quoted Python attribute receivers

### DIFF
--- a/graphtage/pydiff.py
+++ b/graphtage/pydiff.py
@@ -61,8 +61,8 @@ class PyObjAttribute(DataClassNode):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if isinstance(object, StringNode):
-            object.quoted = False
+        if isinstance(self.object, StringNode):
+            self.object.quoted = False
         self.attr.quoted = False
 
 

--- a/test/test_pydiff.py
+++ b/test/test_pydiff.py
@@ -1,9 +1,10 @@
 import ast
 import dataclasses
+from io import StringIO
 from unittest import TestCase
 
 import graphtage
-from graphtage.pydiff import PyDiffFormatter, ast_to_tree, build_tree, print_diff
+from graphtage.pydiff import PyDiffFormatter, PyObjAttribute, ast_to_tree, build_tree, print_diff
 
 from .timing import run_with_time_limit
 
@@ -21,6 +22,17 @@ class TestPyDiff(TestCase):
         self.assertTrue(lists)
         for node in tree.dfs():
             self.assertNotIsInstance(node, graphtage.UnorderedListNode)
+
+    def test_attribute_receiver_is_not_quoted(self):
+        stream = StringIO()
+        attribute = PyObjAttribute(graphtage.StringNode("package"), graphtage.StringNode("member"))
+
+        PyDiffFormatter.DEFAULT_INSTANCE.print(
+            graphtage.Printer(out_stream=stream, ansi_color=False),
+            attribute,
+        )
+
+        self.assertEqual("package.member", stream.getvalue())
 
     def test_diff(self):
         t1 = [1, 2, {3: "three"}, 4]


### PR DESCRIPTION
Closes #155.

`PyObjAttribute` checked the builtin `object`, leaving its receiver normalization branch unreachable. Check `self.object` so string receivers render as attribute names instead of quoted string literals.

Adds a focused output regression for the receiver and member rendering path.

Validation:
- `pytest -q` (141 passed)
- `ruff check graphtage test docs bindist`
- `make -C docs html` (succeeds with two pre-existing duplicate-description warnings)
- `uv build`

Co-authored-by: insisong <emmanuelisaacnsisong@gmail.com>