### PR TITLE
Print the raw version string for -dumpversion

### DIFF
--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -217,7 +217,7 @@ def main(argv=None) -> int:
             exit(EXIT_ERROR)
 
     if args.dumpversion:
-        print(' '.join(map(str, version.__version__)))
+        print(version.VERSION_STRING)
         exit(0)
 
     if args.version:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 import unittest
 
+from graphtage import version
 from graphtage.__main__ import EXIT_DIFFERENCES_FOUND, EXIT_ERROR, EXIT_SUCCESS, main
 
 
@@ -66,3 +67,12 @@ class TestCommandLine(unittest.TestCase):
         to_path = self.write('two.json5', '{a: 1,\n')
         status, _ = self.run_graphtage(from_path, to_path)
         self.assertEqual(EXIT_ERROR, status)
+
+    def test_dumpversion_prints_a_bare_version_string(self):
+        """`-dumpversion` joined over the version string, so it printed `0 . 3 . 1` instead of `0.3.1`."""
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(io.StringIO()), \
+                self.assertRaises(SystemExit) as exited:
+            main(['graphtage', '-dumpversion'])
+        self.assertEqual(EXIT_SUCCESS, exited.exception.code)
+        self.assertEqual(version.VERSION_STRING, out.getvalue().strip())


### PR DESCRIPTION
Closes #147

`-dumpversion` writes Graphtage's version to STDOUT so that scripts can consume it. It built that output with `' '.join(map(str, version.__version__))`. `version.__version__` used to be a tuple of version components, but it is now the string `"0.3.1"`, so the join walked the string's characters and printed `0 . 3 . 1`.

The fix prints `version.VERSION_STRING`, the same spelling the `--version` option already uses. Its name states the type the option needs, so the two stay consistent and a future change to how the version is represented cannot silently reintroduce the same failure.

The regression test lives in `test/test_main.py` alongside the other in-process CLI tests. `main()` reaches this branch through the builtin `exit()`, which raises `SystemExit` rather than returning an exit status, so the test asserts on the exception's code instead of using the existing `run_graphtage` helper.

Before:

```console
$ graphtage -dumpversion
0 . 3 . 1
```

After:

```console
$ graphtage -dumpversion
0.3.1
```

## Validation

- `uv run --frozen --extra dev ruff check graphtage test docs bindist` — passes
- `uv run --frozen --extra dev pytest` — 141 passed
- `uv run --frozen --extra dev make -C docs html SPHINXOPTS="-W --keep-going"` — build succeeded
- `uv lock --check` — fails in my environment because of a local `exclude-newer` setting; it fails the same way on an unmodified checkout of `master`, and this change touches no dependencies, so `uv.lock` is unchanged.

The test was run against the unfixed code first and failed with `AssertionError: '0.3.1' != '0 . 3 . 1'`, then passed after the one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa