### PR TITLE
Preserve node syntax when printing data class edits

### DIFF
--- a/graphtage/dataclasses.py
+++ b/graphtage/dataclasses.py
@@ -3,7 +3,7 @@ from typing import get_origin
 
 from . import AbstractCompoundEdit, Edit, Range, Replace
 from .printer import Fore, Printer
-from .tree import ContainerNode, TreeNode
+from .tree import ContainerNode, GraphtageFormatter, TreeNode
 
 
 class DataClassEdit(AbstractCompoundEdit):
@@ -29,6 +29,20 @@ class DataClassEdit(AbstractCompoundEdit):
 
     def tighten_bounds(self) -> bool:
         return any(edit.tighten_bounds() for edit in self.slot_edits)
+
+    def print(self, formatter: GraphtageFormatter, printer: Printer):
+        """Prints this edit by delegating to the formatter for the node being edited.
+
+        The default :meth:`graphtage.AbstractCompoundEdit.print` implementation prints the slot edits back to back,
+        which drops whatever syntax the node's formatter writes between the slots. Delegating to the node formatter
+        keeps that syntax, and the formatter reaches the slot edits as it prints each child.
+
+        This is equivalent to::
+
+            formatter.get_formatter(self.from_node)(printer, self.from_node)
+
+        """
+        formatter.get_formatter(self.from_node)(printer, self.from_node)
 
 
 class DataClassNode(ContainerNode):

--- a/test/test_pydiff.py
+++ b/test/test_pydiff.py
@@ -1,11 +1,24 @@
 import ast
 import dataclasses
+from io import StringIO
 from unittest import TestCase
 
 import graphtage
+from graphtage.printer import Printer
 from graphtage.pydiff import PyDiffFormatter, ast_to_tree, build_tree, print_diff
 
 from .timing import run_with_time_limit
+
+
+def render_diff(from_source: str, to_source: str) -> str:
+    """Diffs two Python sources and returns the rendering produced by :class:`PyDiffFormatter`."""
+    from_tree = ast_to_tree(ast.parse(from_source))
+    to_tree = ast_to_tree(ast.parse(to_source))
+    stream = StringIO()
+    printer = Printer(out_stream=stream, ansi_color=False)
+    with printer:
+        PyDiffFormatter.DEFAULT_INSTANCE.print(printer, from_tree.diff(to_tree))
+    return stream.getvalue().strip()
 
 
 class TestPyDiff(TestCase):
@@ -46,6 +59,21 @@ class TestPyDiff(TestCase):
         self.assertIsInstance(kvp, graphtage.KeyValuePairNode)
         self.assertIsInstance(kvp.key, graphtage.StringNode)
         self.assertIsInstance(kvp.value, graphtage.ListNode)
+
+    def test_dataclass_edit_preserves_syntax(self):
+        """Reproduces https://github.com/trailofbits/graphtage/issues/150
+
+        Without `DataClassEdit.print`, an edited `DataClassNode` falls back to `AbstractCompoundEdit.print`, which
+        prints the slot edits back to back and drops the syntax the node formatter writes between them. The first
+        case below rendered as `[x]foo[1,2,++3++]`.
+        """
+        self.assertEqual("x = foo(1, 2, ++3++)", render_diff("x = foo(1, 2)", "x = foo(1, 2, 3)"))
+        self.assertEqual("x -> y = foo(1, 2)", render_diff("x = foo(1, 2)", "y = foo(1, 2)"))
+        self.assertEqual("x = ~~foo~~++bar++(1, 2)", render_diff("x = foo(1, 2)", "x = bar(1, 2)"))
+
+    def test_attribute_edit_preserves_separators(self):
+        """An edited `PyObjAttribute` keeps the dots between its slots; it used to render as `[x]abc -> d`."""
+        self.assertEqual("x = a.b.c -> d", render_diff("x = a.b.c", "x = a.b.d"))
 
     def test_infinite_loop(self):
         """Reproduces https://github.com/trailofbits/graphtage/issues/82"""


### PR DESCRIPTION
Closes #150

`DataClassEdit` had no `print()` override, so an edited `DataClassNode` was rendered by
`AbstractCompoundEdit.print`, which prints each slot edit back to back. That drops whatever syntax the
node's formatter writes between the slots.

`SequenceEdit`, the other container edit type, already hands control back to the node's formatter, which
writes the syntax and reaches the sub-edits as it prints each child. `DataClassEdit` now does the same.
This affects any `DataClassNode` whose rendering needs punctuation between its slots, so it is a
prerequisite for correct diff rendering in #151 and #154.

A `print_DataClassEdit` formatter method would be the wrong place for this: `print_StringEdit` is the only
`print_<Edit>` formatter in the package, and it exists because a character-level string diff has no
node-level rendering. `get_formatter` always resolves here, because `DataClassNode` is a `ContainerNode`
and formatters find `print_ContainerNode` through the MRO.

| Diff | Before | After |
| --- | --- | --- |
| `x = foo(1, 2)` -> `x = foo(1, 2, 3)` | `[x]foo[1,2,++3++]` | `x = foo(1, 2, ++3++)` |
| `x = foo(1, 2)` -> `y = foo(1, 2)` | `[x -> y]foo[1,2]` | `x -> y = foo(1, 2)` |
| `x = foo(1, 2)` -> `x = bar(1, 2)` | `[x]x = ~~foo~~++bar++(1, 2)` | `x = ~~foo~~++bar++(1, 2)` |
| `x = a.b.c` -> `x = a.b.d` | `[x]abc -> d` | `x = a.b.c -> d` |

## Validation

- Two new tests in `test/test_pydiff.py` cover `Assignment`, `Call`, and `PyObjAttribute`. Both fail
  against the unfixed code with the "Before" strings above, and pass with the fix.
- `ruff check graphtage test docs bindist`: passes.
- `pytest`: 142 passed.
- `make -C docs html SPHINXOPTS="-W --keep-going"`: build succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa