### PR TITLE
Fix miscased Fore.Yellow in DataClassNode.print

### DIFF
--- a/graphtage/dataclasses.py
+++ b/graphtage/dataclasses.py
@@ -147,7 +147,7 @@ class DataClassNode(ContainerNode):
         return sum(s.calculate_total_size() for s in self)
 
     def print(self, printer: Printer):
-        with printer.color(Fore.Yellow):
+        with printer.color(Fore.YELLOW):
             printer.write(self.__class__.__name__)
         printer.write("(")
         for i, slot in enumerate(self._SLOTS):

--- a/test/test_dataclasses.py
+++ b/test/test_dataclasses.py
@@ -1,7 +1,9 @@
+from io import StringIO
 from unittest import TestCase
 
 from graphtage import IntegerNode, Replace, StringNode
 from graphtage.dataclasses import DataClassEdit, DataClassNode
+from graphtage.printer import Fore, Printer
 
 
 class TestDataclasses(TestCase):
@@ -47,6 +49,25 @@ class TestDataclasses(TestCase):
         c = Foo(IntegerNode(12))
         edit = f.edits(c)
         self.assertIsInstance(edit, DataClassEdit)
+
+    def test_print_renders_slots(self):
+        """:meth:`DataClassNode.print` is the fallback when no formatter resolves the node type."""
+        class Foo(DataClassNode):
+            name: StringNode
+            count: IntegerNode
+
+        stream = StringIO()
+        Foo(name=StringNode("x"), count=IntegerNode(3)).print(Printer(out_stream=stream, ansi_color=False))
+        self.assertEqual('Foo(name="x", count=3)', stream.getvalue())
+
+    def test_print_colors_the_class_name_yellow(self):
+        """The class name must be yellow; ``Fore.Yellow`` used to raise :exc:`AttributeError` here."""
+        class Foo(DataClassNode):
+            name: StringNode
+
+        stream = StringIO()
+        Foo(name=StringNode("x")).print(Printer(out_stream=stream, ansi_color=True))
+        self.assertIn(f"{Fore.YELLOW}Foo", stream.getvalue())
 
     def test_inheritance_with_duplicate(self):
         def define_duplicate():


### PR DESCRIPTION
Closes #153

`graphtage/dataclasses.py:150` spelled the colorama attribute as `Fore.Yellow`. The real attribute is `Fore.YELLOW`, which is what every other call site in the package uses, so `DataClassNode.print()` raised `AttributeError: 'AnsiFore' object has no attribute 'Yellow'` every time it ran.

`DataClassNode.print()` is the fallback rendering path that `TreeNode.print()` takes when no formatter resolves the node type (`graphtage/tree.py:72-76`), so any `DataClassNode` subclass without a dedicated formatter crashed instead of printing. The failure was not limited to color output: the attribute is read to build the argument to `printer.color()`, before the `only_ansi` wrapper on that method can skip the context, so it also crashed with `ansi_color=False`.

The fix is one character. The rest of `DataClassNode.print()` renders correctly once it is reachable — `Foo(name="x", count=3)`, with the class name yellow, the slot names red, and the `=` bright.

## Validation

Two regression tests in `test/test_dataclasses.py` call `DataClassNode.print()` directly, which is what reaches the buggy path:

- `test_print_renders_slots` asserts the uncolored rendering equals `Foo(name="x", count=3)`.
- `test_print_colors_the_class_name_yellow` asserts `Fore.YELLOW` precedes the class name under `ansi_color=True`.

Both tests were confirmed to catch the bug:

- Against the unfixed code, both fail with `AttributeError: 'AnsiFore' object has no attribute 'Yellow'`.
- With the color context removed entirely rather than corrected, `test_print_colors_the_class_name_yellow` fails on the missing escape, so a silently dropped color is caught as well as a crash.

Local CI, all passing:

- `ruff check graphtage test docs bindist`
- `pytest` (142 passed)
- `make -C docs html SPHINXOPTS="-W --keep-going"`

`uv lock --check` reports the lockfile needs updating, but it does so identically on a pristine checkout of `master` in this environment (a global `exclude-newer` setting forces re-resolution). Neither `pyproject.toml` nor `uv.lock` is touched by this change.

I also grepped the package for other miscased colorama attributes across `Fore.`, `Back.`, and `Style.`. This was the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa