### PR TITLE
Fix Subscript rendering in both printing paths

### DIFF
--- a/graphtage/ast.py
+++ b/graphtage/ast.py
@@ -87,7 +87,7 @@ class Subscript(DataClassNode):
         self.value.print(printer)
         with printer.color(Fore.LIGHTBLUE_EX):
             printer.write("[")
-        self.slice.write(printer)
+        self.slice.print(printer)
         with printer.color(Fore.LIGHTBLUE_EX):
             printer.write("]")
 

--- a/graphtage/pydiff.py
+++ b/graphtage/pydiff.py
@@ -433,7 +433,7 @@ class PyDiffFormatter(GraphtageFormatter):
             printer.write("[")
         self.print(printer, node.slice)
         with printer.color(Fore.BLUE):
-            printer.write("[")
+            printer.write("]")
 
 
 def diff(from_py_obj, to_py_obj, options: BuildOptions | None = None):

--- a/test/test_pydiff.py
+++ b/test/test_pydiff.py
@@ -1,8 +1,11 @@
 import ast
 import dataclasses
+from io import StringIO
 from unittest import TestCase
 
 import graphtage
+from graphtage.ast import Subscript
+from graphtage.printer import Printer
 from graphtage.pydiff import PyDiffFormatter, ast_to_tree, build_tree, print_diff
 
 from .timing import run_with_time_limit
@@ -46,6 +49,29 @@ class TestPyDiff(TestCase):
         self.assertIsInstance(kvp, graphtage.KeyValuePairNode)
         self.assertIsInstance(kvp.key, graphtage.StringNode)
         self.assertIsInstance(kvp.value, graphtage.ListNode)
+
+    def _only_subscript(self, source: str) -> Subscript:
+        subscripts = [node for node in ast_to_tree(ast.parse(source)).dfs() if isinstance(node, Subscript)]
+        self.assertEqual(1, len(subscripts))
+        return subscripts[0]
+
+    def test_subscript_node_print(self):
+        """Reproduces the ``TreeNode.write`` half of https://github.com/trailofbits/graphtage/issues/154
+
+        ``Subscript.print`` is the fallback that :meth:`graphtage.tree.GraphtageFormatter.print` uses when no
+        formatter resolves the node type, so this calls it directly rather than through a formatter.
+
+        """
+        stream = StringIO()
+        self._only_subscript("a[1]").print(Printer(out_stream=stream, ansi_color=False))
+        self.assertEqual("a[1]", stream.getvalue())
+
+    def test_subscript_formatter_print(self):
+        """Reproduces the unbalanced bracket half of https://github.com/trailofbits/graphtage/issues/154"""
+        stream = StringIO()
+        node = self._only_subscript("a[1]")
+        PyDiffFormatter.DEFAULT_INSTANCE.print(Printer(out_stream=stream, ansi_color=False), node)
+        self.assertEqual("a[1]", stream.getvalue())
 
     def test_infinite_loop(self):
         """Reproduces https://github.com/trailofbits/graphtage/issues/82"""


### PR DESCRIPTION
Closes #154

`Subscript` nodes have two printing paths, and each had its own defect. They are mutually exclusive at runtime: `PyDiffFormatter.print_Subscript` shadows `ast.Subscript.print` whenever `PyDiffFormatter` is in play, and the node's own `print` only runs as the `tree.py` fallback when no formatter resolves the type. That is why both defects went unnoticed.

- `graphtage/ast.py`: `Subscript.print` called `self.slice.write(printer)`. `TreeNode` has no `write` method, so the fallback path emitted `a[` and then raised `AttributeError: 'IntegerNode' object has no attribute 'write'`. It now calls `self.slice.print(printer)`, matching the surrounding lines.
- `graphtage/pydiff.py`: `PyDiffFormatter.print_Subscript` wrote an opening bracket where the closing one belongs, so an unedited `a[1]` rendered as `a[1[`.

The two regression tests in `test/test_pydiff.py` reach each path deliberately: one calls the node's `print` method directly, the other goes through `PyDiffFormatter`. Assertions stay at the unedited-tree level, because a *diff* of `a[1]` against `a[2]` reaches neither path (`DataClassEdit` has no `print()` override, issue #150).

## Validation

Both new tests were run against the unfixed source first and each failed on its own defect: `test_subscript_node_print` with `AttributeError: 'IntegerNode' object has no attribute 'write'`, and `test_subscript_formatter_print` with `AssertionError: 'a[1]' != 'a[1['`. Both pass after the fix.

- `ruff check graphtage test docs bindist`: passes
- `pytest`: 142 passed
- `make -C docs html SPHINXOPTS="-W --keep-going"`: build succeeded
- `uv lock --check`: unchanged by this PR; no dependency edits were made

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa