### PR TITLE
Build a Graphtage tree from plain import statements

### DIFF
--- a/graphtage/pydiff.py
+++ b/graphtage/pydiff.py
@@ -204,8 +204,9 @@ class ASTBuilder(BasicBuilder):
             CallKeywords(())
         )
 
+    @Builder.expander(ast.Import)
     @Builder.expander(ast.ImportFrom)
-    def expand_import_from(self, node: ast.ImportFrom):
+    def expand_import(self, node: ast.Import | ast.ImportFrom):
         return node.names
 
     @Builder.builder(ast.ImportFrom)
@@ -215,6 +216,21 @@ class ASTBuilder(BasicBuilder):
         else:
             from_name = StringNode(node.module, quoted=False)
         return Import(names=ListNode(children), from_name=from_name)
+
+    @Builder.builder(ast.Import)
+    def build_import(self, _, children: list[TreeNode]):
+        """Builds a plain ``import x`` statement.
+
+        :class:`ast.Import` has no module of its own, so the resulting :class:`graphtage.ast.Import` gets an empty
+        ``from_name``, which is how both the node and its formatter distinguish ``import x`` from ``from y import x``.
+
+        Args:
+            children: The :class:`PyAlias` nodes built from the statement's aliases.
+
+        Returns:
+            Import: The resulting node.
+        """
+        return Import(names=ListNode(children), from_name=StringNode("", quoted=False))
 
     @Builder.builder(ast.alias)
     def build_alias(self, node: ast.alias, _):

--- a/test/test_pydiff.py
+++ b/test/test_pydiff.py
@@ -1,11 +1,21 @@
 import ast
 import dataclasses
+from io import StringIO
 from unittest import TestCase
 
 import graphtage
-from graphtage.pydiff import PyDiffFormatter, ast_to_tree, build_tree, print_diff
+from graphtage.ast import Import
+from graphtage.pydiff import PyAlias, PyDiffFormatter, ast_to_tree, build_tree, print_diff
 
 from .timing import run_with_time_limit
+
+
+def format_tree(tree: graphtage.TreeNode) -> str:
+    stream = StringIO()
+    printer = graphtage.printer.Printer(out_stream=stream, ansi_color=False)
+    with printer:
+        PyDiffFormatter.DEFAULT_INSTANCE.print(printer, tree)
+    return stream.getvalue()
 
 
 class TestPyDiff(TestCase):
@@ -21,6 +31,36 @@ class TestPyDiff(TestCase):
         self.assertTrue(lists)
         for node in tree.dfs():
             self.assertNotIsInstance(node, graphtage.UnorderedListNode)
+
+    def test_plain_import_builds(self):
+        """Reproduces https://github.com/trailofbits/graphtage/issues/151.
+
+        `ASTBuilder` had no builder for `ast.Import`, so every module containing a plain `import` statement raised
+        `NotImplementedError`.
+
+        """
+        expected = {
+            "import os": [("os", "")],
+            "import os.path": [("os.path", "")],
+            "import os as o": [("os", "o")],
+            "import os, sys": [("os", ""), ("sys", "")],
+        }
+        for source, aliases in expected.items():
+            with self.subTest(source=source):
+                imports = [node for node in ast_to_tree(ast.parse(source)).dfs() if isinstance(node, Import)]
+                self.assertEqual(1, len(imports))
+                self.assertEqual("", imports[0].from_name.object)
+                names = imports[0].names.children()
+                for name, (expected_name, expected_as_name) in zip(names, aliases, strict=True):
+                    self.assertIsInstance(name, PyAlias)
+                    self.assertEqual(expected_name, name.name.object)
+                    self.assertEqual(expected_as_name, name.as_name.object)
+
+    def test_plain_import_printing(self):
+        """A plain `import` must not render the `from` clause that `from x import y` gets."""
+        for source in ("import os", "import os.path", "import os, sys", "from os import path"):
+            with self.subTest(source=source):
+                self.assertEqual(f"{source}\n", format_tree(ast_to_tree(ast.parse(source))))
 
     def test_diff(self):
         t1 = [1, 2, {3: "three"}, 4]


### PR DESCRIPTION
Closes #151

`ASTBuilder` registered an expander and a builder for `ast.ImportFrom` but nothing for `ast.Import`, so
`ast_to_tree(ast.parse("import os"))` raised `NotImplementedError`. Since `import x` is far more common than
`from y import x`, most real Python sources could not be diffed at all.

Both `ast.Import` and `ast.ImportFrom` expose their aliases as `.names`, so `ast.Import` joins the existing
expander. The new builder produces the same `graphtage.ast.Import` node with an empty `from_name`; the node's
`print` and `PyImportFormatter.print_Import` already treat an empty `from_name` as the plain `import x` form, so
nothing on the printing side changes.

The expander was renamed from `expand_import_from` to `expand_import` because it now handles both statement forms.
Builder registration is decorator-based, so the name is not part of the dispatch.

## Validation

The regression tests were run against the unfixed builder first. All seven subtests failed with
`NotImplementedError: A builder for type Import is not defined for object Import(names=[alias(name='os', ...)])`,
and all pass with the fix. `test_plain_import_builds` covers `import os`, `import os.path`, `import os as o`, and
`import os, sys`; `test_plain_import_printing` checks the rendered statement and keeps `from os import path` as a
control. Both tests work at the tree-construction and unedited-printing level, so they do not depend on the
separate diff-rendering problem in #150.

- `ruff check graphtage test docs bindist`: passes
- `pytest`: 142 passed, 8 subtests passed
- `make -C docs html SPHINXOPTS="-W --keep-going"`: build succeeded
- `uv lock --check`: fails identically on an unmodified checkout because of a local `exclude-newer` setting; no
  dependency changed here

## Out of scope

Most other statement and expression node types still have no builder, including `FunctionDef`, `ClassDef`, `If`,
`For`, `While`, `With`, `Try`, `BinOp`, `Compare`, `AugAssign`, `AnnAssign`, `Lambda`, the comprehensions,
`Starred`, `Raise`, `Assert`, `Delete`, `Pass`, `JoinedStr`, `Slice`, `Match`, and the `Async*` variants. Alias
`asname` values also render quoted (`from os import path as "p"`), which predates this change and affects
`ImportFrom` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa