### PR TITLE
Run post_init for the class being instantiated

### DIFF
--- a/docs/builders.rst
+++ b/docs/builders.rst
@@ -160,7 +160,8 @@ Initializing a Data Class Node
 :meth:`DataClassNode.__init__ <graphtage.dataclasses.DataClassNode.__init__>` assigns the slots from its positional
 and keyword arguments, so overriding it means reimplementing that assignment. Override
 :meth:`graphtage.dataclasses.DataClassNode.post_init` instead. It is called once the slots have been assigned, and it
-should not call ``super().post_init()``: each ancestor's implementation is called in turn, in order of the ``__mro__``.
+should not call ``super().post_init()``: every implementation in the class hierarchy is called automatically,
+starting with the least derived data class and ending with the class being instantiated.
 
 .. code-block:: python
 
@@ -171,7 +172,4 @@ should not call ``super().post_init()``: each ancestor's implementation is calle
             self.name.quoted = False
 
 .. note::
-    As of Graphtage 0.3.1, ``post_init()`` is only called for the ancestors of the class being instantiated, never for
-    the class itself. ``UnquotedName(StringNode("x"))`` leaves ``quoted`` set to :const:`True`; the callback runs only
-    when a subclass of ``UnquotedName`` is instantiated. Code that must run for the class itself still has to go in
-    ``__init__``.
+    An implementation that a subclass inherits without overriding runs once, not once per class that inherits it.

--- a/graphtage/dataclasses.py
+++ b/graphtage/dataclasses.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from typing import get_origin
 
 from . import AbstractCompoundEdit, Edit, Range, Replace
@@ -37,6 +37,7 @@ class DataClassNode(ContainerNode):
     _SLOTS: tuple[str, ...]
     _SLOT_ANNOTATIONS: dict[str, type[TreeNode]]
     _DATA_CLASS_ANCESTORS: list[type["DataClassNode"]]
+    _POST_INITS: tuple[Callable[["DataClassNode"], None], ...]
 
     def __init__(self, *args, **kwargs):
         """Be careful extending __init__; consider using :func:`DataClassNode.post_init` instead."""
@@ -74,14 +75,15 @@ class DataClassNode(ContainerNode):
             setattr(self, s, value)
         # self.__hash__ gets called so often, we cache the result:
         self.__hash = hash(tuple(self))
-        for ancestor in self._DATA_CLASS_ANCESTORS:
-            ancestor.post_init(self)
+        for post_init in self._POST_INITS:
+            post_init(self)
 
     def post_init(self):
-        """Callback called after this class's members have been initialized.
+        """Callback called after this node's slots have been initialized.
 
-        This callback should not call `super().post_init()`. Each superclass's `post_init()` will be automatically
-        called in order of the `__mro__`.
+        This callback should not call `super().post_init()`. Every implementation in the class hierarchy is called
+        automatically, starting with the least derived data class and ending with the class being instantiated. An
+        implementation that a subclass inherits without overriding is called only once.
         """
         pass
 
@@ -89,10 +91,16 @@ class DataClassNode(ContainerNode):
         super().__init_subclass__(**kwargs)
         ancestors = [
             c
-            for c in cls.__mro__
+            for c in reversed(cls.__mro__)
             if c is not cls and issubclass(c, DataClassNode) and c is not DataClassNode
         ]
         cls._DATA_CLASS_ANCESTORS = ancestors
+        # Selecting on __dict__ keeps an inherited implementation from being called once per class that inherits it.
+        cls._POST_INITS = tuple(
+            c.__dict__["post_init"]
+            for c in (*ancestors, cls)
+            if "post_init" in c.__dict__
+        )
         ancestor_slot_names = {
             name: a
             for a in ancestors

--- a/test/test_dataclasses.py
+++ b/test/test_dataclasses.py
@@ -8,17 +8,17 @@ class TestDataclasses(TestCase):
     def test_inheritance(self):
         class Foo(DataClassNode):
             foo: IntegerNode
-            initialized = False
+            foo_initialized = False
 
             def post_init(self):
-                self.initialized = True
+                self.foo_initialized = True
 
         class Bar(Foo):
             bar: StringNode
-            initialized = False
+            bar_initialized = False
 
             def post_init(self):
-                self.initialized = True
+                self.bar_initialized = True
 
         self.assertEqual(("foo",), Foo._SLOTS)
         self.assertEqual(0, len(Foo._DATA_CLASS_ANCESTORS))
@@ -28,13 +28,15 @@ class TestDataclasses(TestCase):
         b = Bar(foo=IntegerNode(10), bar=StringNode("bar"))
         self.assertEqual(10, b.foo.object)
         self.assertEqual("bar", b.bar.object)
-        self.assertTrue(b.initialized)
+        self.assertTrue(b.foo_initialized)
+        self.assertTrue(b.bar_initialized)
 
         # now test a mixture of positional and keyword arguments
         b = Bar(StringNode("bar"), foo=IntegerNode(10))
         self.assertEqual(10, b.foo.object)
         self.assertEqual("bar", b.bar.object)
-        self.assertTrue(b.initialized)
+        self.assertTrue(b.foo_initialized)
+        self.assertTrue(b.bar_initialized)
 
         # test equality
         self.assertEqual(Bar(IntegerNode(10), StringNode("bar")), b)
@@ -47,6 +49,46 @@ class TestDataclasses(TestCase):
         c = Foo(IntegerNode(12))
         edit = f.edits(c)
         self.assertIsInstance(edit, DataClassEdit)
+
+    def test_post_init_runs_once_per_implementation(self):
+        calls: list[tuple[str, str]] = []
+
+        class Base(DataClassNode):
+            base: IntegerNode
+
+            def post_init(self):
+                calls.append(("Base", type(self).__name__))
+
+        class Middle(Base):
+            middle: StringNode
+
+        class Derived(Middle):
+            derived: IntegerNode
+
+            def post_init(self):
+                calls.append(("Derived", type(self).__name__))
+
+        Base(IntegerNode(1))
+        self.assertEqual([("Base", "Base")], calls)
+
+        # Middle inherits Base.post_init without overriding it, so it must run exactly once
+        calls.clear()
+        Middle(IntegerNode(1), StringNode("middle"))
+        self.assertEqual([("Base", "Middle")], calls)
+
+        # each implementation runs once, least derived first
+        calls.clear()
+        Derived(IntegerNode(1), StringNode("middle"), IntegerNode(2))
+        self.assertEqual([("Base", "Derived"), ("Derived", "Derived")], calls)
+
+    def test_post_init_runs_for_direct_subclass(self):
+        class Unquoted(DataClassNode):
+            name: StringNode
+
+            def post_init(self):
+                self.name.quoted = False
+
+        self.assertFalse(Unquoted(StringNode("name")).name.quoted)
 
     def test_inheritance_with_duplicate(self):
         def define_duplicate():


### PR DESCRIPTION
Closes #149

`DataClassNode.__init__` called `post_init()` only on the entries of `_DATA_CLASS_ANCESTORS`, which excludes the
class being constructed. A subclass that used the documented extension point instead of overriding `__init__` never
had its callback run, and nothing reported the omission: the callback began firing only once some other class
subclassed it. The ancestor list was also in `__mro__` order, most derived first, so ancestor callbacks ran in the
reverse of constructor order, contradicting the base-up initialization the `post_init()` docstring described.

Each class in the hierarchy that defines its own `post_init` is now recorded at class-definition time, least derived
first and ending with the class itself. Selecting on `__dict__` keeps an implementation that a subclass inherits
without overriding from running once per inheriting class, so subclasses of a data class still get exactly one call.

`docs/builders.rst` carried a note documenting the old behavior as a limitation; it is replaced with the inherited
implementation rule.

No `DataClassNode` subclass in the package defines `post_init` (`graphtage/ast.py` and `graphtage/pydiff.py` use
`__init__` overrides), so no in-tree node changes behavior.

## Validation

Three tests in `test/test_dataclasses.py` were confirmed to fail against the unfixed code and pass after the fix:

- `test_post_init_runs_once_per_implementation` asserts the call order and count for a three-level hierarchy where the
  middle class inherits its `post_init` (expected `[("Base", "Derived"), ("Derived", "Derived")]`; the unfixed code
  produced `[]` for the first instantiation).
- `test_post_init_runs_for_direct_subclass` covers the `UnquotedName` example from the docs.
- `test_inheritance` was strengthened: both `Foo.post_init` and `Bar.post_init` set distinct flags, so the assertion no
  longer passes when only the ancestor's callback runs. It previously passed by accident.

The reproducer from the issue now prints `[('Node1', 'Node1')]` for the direct instantiation, and a diamond hierarchy
calls each implementation once in base-first order.

Local CI:

- `ruff check graphtage test docs bindist`: passed
- `pytest`: 142 passed
- `make -C docs html SPHINXOPTS="-W --keep-going"`: build succeeded
- `uv lock --check`: fails in this sandbox on an unmodified checkout of `master` as well, because of a global
  `exclude-newer` timestamp. No dependency files were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa