### PR TITLE
Make --match-if match the semantics of --match-unless

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ options apply only to ordered lists.
 ### Match Constraints
 The `--match-unless` or `-u` and `--match-if` or `-m` options take an expression that decides whether Graphtage may
 pair two nodes. Graphtage evaluates the expression once for each pair of nodes it considers, with `from` bound to the
-node from the first file and `to` bound to the node from the second. `--match-unless` refuses the pair when the
-expression is true; `--match-if` refuses it unless the expression is true. A refused pair is reported as a wholesale
-replacement rather than compared element by element.
+plain Python value of the node from the first file and `to` bound to the plain Python value of the node from the
+second. `--match-unless` refuses the pair when the expression is true; `--match-if` refuses it unless the expression
+is true. A refused pair is reported as a wholesale replacement rather than compared element by element.
 
 Expressions are parsed by the `graphtage.expressions` module rather than by `eval`. They support arithmetic and
 comparison operators, indexing, attribute lookup, and calls to a fixed set of builtins such as `len` and `sorted`.
@@ -225,12 +225,32 @@ $ graphtage --match-unless "from['id'] != to['id']" servers.json servers.new.jso
     }
 }
 ```
-The two options differ in more than the sense of the test. `--match-unless` binds `from` and `to` to plain Python
-values, and leaves a pair unconstrained when the expression raises an error, which is what makes the example above
-work on the records without also constraining the strings and integers underneath them. `--match-if` binds `from` and
-`to` to Graphtage node objects, and refuses a pair when the expression raises an error. Because the constraint applies
-to every node in the tree, including the two roots, an expression that reads a key such as `from['id'] == to['id']`
-refuses every pair and collapses the whole diff into one replacement. Prefer `--match-unless`.
+The same constraint written with `--match-if` produces the same diff:
+```console
+$ graphtage --match-if "from['id'] == to['id']" servers.json servers.new.json
+```
+```json
+{
+    "primary": {
+        "host": "alpha++s++",
+        "id": 1
+    },
+    "replica": {
+        "host": "beta",
+        "id": 2
+    } -> {
+        "host": "gamma",
+        "id": 3
+    }
+}
+```
+Graphtage applies the constraint to every node in the tree, not only to the dictionaries the expression was written
+for. A pair for which the expression raises an error is left unconstrained, which is what lets the expression above
+constrain the two records without also constraining the strings and integers underneath them, where subscripting by
+`'id'` has no meaning.
+
+Because of that, an expression that raises for every pair constrains nothing at all. If a constraint appears to have
+no effect, run the same command with `--debug`, which logs the error Graphtage caught for each pair it skipped.
 
 ### ANSI Color
 By default, Graphtage will only use ANSI color in its output if it is run from a TTY. If, for example, you would like

--- a/graphtage/__main__.py
+++ b/graphtage/__main__.py
@@ -114,10 +114,12 @@ def main(argv=None) -> int:
             help=f'equivalent to `--to-mime {mime}`'
         )
     parser.add_argument('--match-if', '-m', type=str, default=None,
-                        help='only attempt to match two dictionaries if the provided expression is satisfied. For '
-                             'example, `--match-if "from[\'foo\'] == to[\'bar\']"` will mean that only a dictionary '
-                             'which has a "foo" key that has the same value as the other dictionary\'s "bar" key will '
-                             'be attempted to be paired')
+                        help='only attempt to match two nodes if the provided expression is satisfied. `from` and '
+                             '`to` are bound to the plain Python values of the two nodes. For example, `--match-if '
+                             '"from[\'foo\'] == to[\'bar\']"` will mean that only a dictionary which has a "foo" key '
+                             'that has the same value as the other dictionary\'s "bar" key will be attempted to be '
+                             'paired. A pair for which the expression raises an error, such as the strings and '
+                             'numbers beneath a dictionary, is left unconstrained')
     parser.add_argument('--match-unless', '-u', type=str, default=None,
                         help='similar to `--match-if`, but only attempt a match if the provided expression evaluates '
                              'to `False`')

--- a/graphtage/constraints.py
+++ b/graphtage/constraints.py
@@ -8,6 +8,16 @@ log = logging.getLogger('graphtage')
 
 
 class ConditionalMatcher(metaclass=ABCMeta):
+    """Decides whether two nodes may be paired, based on a commandline expression.
+
+    The expression is evaluated with ``from`` and ``to`` bound to the :meth:`TreeNode.to_obj` representations of the
+    two nodes, so it operates on plain Python values rather than on Graphtage's node objects.
+
+    Constraints are attached to every node of a tree, so an expression written for one kind of node will raise on the
+    others; for example, subscripting a string by a dictionary key raises a :class:`TypeError`. An expression that
+    raises leaves the pair unconstrained rather than refusing it.
+    """
+
     def __init__(self, condition: expressions.Expression):
         self.condition: expressions.Expression = condition
 
@@ -21,16 +31,21 @@ class ConditionalMatcher(metaclass=ABCMeta):
 
 
 class MatchIf(ConditionalMatcher):
+    """Refuses to pair two nodes unless the condition evaluates to a true value."""
+
     def __call__(self, from_node: graphtage.TreeNode, to_node: graphtage.TreeNode) -> Edit | None:
         try:
-            if self.condition.eval(locals={'from': from_node, 'to': to_node}):
+            if self.condition.eval(locals={'from': from_node.to_obj(), 'to': to_node.to_obj()}):
                 return None
         except Exception as e:
             log.debug(f"{e!s} while evaluating --match-if for nodes {from_node} and {to_node}")
+            return None
         return graphtage.Replace(from_node, to_node)
 
 
 class MatchUnless(ConditionalMatcher):
+    """Refuses to pair two nodes when the condition evaluates to a true value."""
+
     def __call__(self, from_node: graphtage.TreeNode, to_node: graphtage.TreeNode) -> Edit | None:
         try:
             if self.condition.eval(locals={'from': from_node.to_obj(), 'to': to_node.to_obj()}):

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -1,34 +1,106 @@
+from typing import Any
 from unittest import TestCase
 
 import graphtage
 from graphtage import expressions
-from graphtage.constraints import MatchIf, MatchUnless
+from graphtage.constraints import ConditionalMatcher, MatchIf, MatchUnless
+from graphtage.edits import Edit
 from graphtage.json import build_tree
 
 
-class TestConstraints(TestCase):
-    def test_match_if(self):
-        expr = expressions.parse("from.key == 'foo' && to.key == 'bar'")
-        from_tree = build_tree({
-            "foo": [1, 2, 3]
-        })
-        for node in from_tree.dfs():
-            MatchIf.apply(node, expr)
-        to_tree = build_tree({
-            "bar": [1, 2, 4]
-        })
-        diff = from_tree.diff(to_tree)
-        self.assertIsInstance(diff.edit, graphtage.Replace)
+def diff_with_constraint(matcher: type[ConditionalMatcher], expression: str, from_obj: Any, to_obj: Any) -> Edit:
+    """Diffs two Python objects with a matcher applied to every node of the first tree.
 
-    def test_match_unless(self):
-        expr = expressions.parse("from.key == 'foo' && to.key == 'bar'")
-        from_tree = build_tree({
-            "foo": [1, 2, 3]
-        })
-        for node in from_tree.dfs():
-            MatchUnless.apply(node, expr)
-        to_tree = build_tree({
-            "bar": [1, 2, 4]
-        })
-        diff = from_tree.diff(to_tree)
-        self.assertIsInstance(diff.edit, graphtage.MultiSetEdit)
+    This mirrors what ``graphtage.__main__`` does for ``--match-if`` and ``--match-unless``: the constraint is
+    attached to every node reached by a depth-first search, not only to the root.
+
+    Args:
+        matcher: the :class:`ConditionalMatcher` subclass to apply.
+        expression: the constraint expression, in the syntax accepted by :mod:`graphtage.expressions`.
+        from_obj: the Python object to build the "from" tree from.
+        to_obj: the Python object to build the "to" tree from.
+
+    Returns:
+        Edit: the edit produced for the roots of the two trees.
+    """
+    condition = expressions.parse(expression)
+    from_tree = build_tree(from_obj)
+    for node in from_tree.dfs():
+        matcher.apply(node, condition)
+    return from_tree.diff(build_tree(to_obj)).edit
+
+
+class TestConstraints(TestCase):
+    """Tests the ``--match-if`` and ``--match-unless`` node pairing constraints."""
+
+    def test_match_if_permits_pair_when_condition_holds(self):
+        """`--match-if` must pair two dicts whose compared values are equal.
+
+        This is the example from the ``--match-if`` help text. It previously failed because ``MatchIf`` bound the
+        raw :class:`graphtage.TreeNode` objects, so ``from['foo']`` was a ``KeyValuePairNode`` carrying its key and
+        therefore never equalled ``to['bar']``.
+        """
+        edit = diff_with_constraint(
+            MatchIf,
+            "from['foo'] == to['bar']",
+            {"foo": "same", "other": 1},
+            {"bar": "same", "other": 2},
+        )
+        self.assertIsInstance(edit, graphtage.MultiSetEdit)
+
+    def test_match_if_refuses_pair_when_condition_fails(self):
+        """`--match-if` must still refuse a pair whose compared values differ."""
+        edit = diff_with_constraint(
+            MatchIf,
+            "from['foo'] == to['bar']",
+            {"foo": "same", "other": 1},
+            {"bar": "different", "other": 2},
+        )
+        self.assertIsInstance(edit, graphtage.Replace)
+
+    def test_match_if_permits_pair_when_expression_raises(self):
+        """A `--match-if` expression that raises must leave the pair unconstrained.
+
+        The constraint is applied to every node, including leaves, where subscripting raises. ``MatchIf`` previously
+        answered such an error with a ``Replace``, which refused every leaf and collapsed the diff even once the
+        operands were bound correctly.
+        """
+        edit = diff_with_constraint(MatchIf, "from['id'] == to['id']", "hello", "hellp")
+        self.assertIsInstance(edit, graphtage.StringEdit)
+
+    def test_match_unless_refuses_pair_when_condition_holds(self):
+        """`--match-unless` must refuse a pair whose compared values differ."""
+        edit = diff_with_constraint(
+            MatchUnless,
+            "from['foo'] != to['bar']",
+            {"foo": "same", "other": 1},
+            {"bar": "different", "other": 2},
+        )
+        self.assertIsInstance(edit, graphtage.Replace)
+
+    def test_match_unless_permits_pair_when_condition_fails(self):
+        """`--match-unless` must pair two dicts whose compared values are equal."""
+        edit = diff_with_constraint(
+            MatchUnless,
+            "from['foo'] != to['bar']",
+            {"foo": "same", "other": 1},
+            {"bar": "same", "other": 2},
+        )
+        self.assertIsInstance(edit, graphtage.MultiSetEdit)
+
+    def test_match_unless_permits_pair_when_expression_raises(self):
+        """A `--match-unless` expression that raises must leave the pair unconstrained."""
+        edit = diff_with_constraint(MatchUnless, "from['id'] != to['id']", "hello", "hellp")
+        self.assertIsInstance(edit, graphtage.StringEdit)
+
+    def test_match_if_and_match_unless_agree(self):
+        """The two options must produce the same diff for logically equivalent expressions.
+
+        The help text presents ``--match-unless`` as ``--match-if`` with the sense of the test inverted, so the two
+        spellings of the same constraint must not disagree.
+        """
+        from_obj = {"foo": "same", "other": 1}
+        to_obj = {"bar": "same", "other": 2}
+        match_if = diff_with_constraint(MatchIf, "from['foo'] == to['bar']", from_obj, to_obj)
+        match_unless = diff_with_constraint(MatchUnless, "from['foo'] != to['bar']", from_obj, to_obj)
+        self.assertIsInstance(match_if, type(match_unless))


### PR DESCRIPTION
Closes #148

`--match-if` refused every pair when used exactly as its own `--help` text describes, collapsing the diff into one
wholesale replacement. **This changes the semantics of `--match-if`.** Expressions that relied on the old behavior —
attribute access on Graphtage node objects, or on an error refusing a pair — will behave differently.

`MatchIf` differed from `MatchUnless` in two ways beyond the sense of the test, and both are fixed here:

1. **Operand binding.** `MatchIf` bound the raw `TreeNode`s; `MatchUnless` bound `from_node.to_obj()` /
   `to_node.to_obj()`. Subscripting a `DictNode` yields a `KeyValuePairNode` carrying both key and value, so
   `from['foo'] == to['bar']` compared two pairs with different keys and was always false — precisely the case the
   documented example exists to allow. `TreeNode.to_obj`'s own docstring already says it exists to supply the objects
   for `--match-if` and `--match-unless`.
2. **Error handling.** On exception `MatchIf` fell through to `return Replace(...)`, refusing the pair; `MatchUnless`
   returned `None`. Constraints are attached to every node by DFS, so they also reach leaves, where subscripting
   raises.

Both changes are required. Binding `to_obj()` alone pairs the roots correctly but still refuses every string and
integer underneath them:

```json
{
    "other": 1 -> "other": 2,
    "foo": "same" -> "bar": "same"
}
```

With both changes, the issue's command produces the same diff as the equivalent `--match-unless` spelling:

```console
$ graphtage --match-if "from['foo'] == to['bar']" original.json modified.json
```
```json
{
    "other": 1 -> 2,
    "~~foo~~++bar++": "same"
}
```

### Other changes

- `test/test_constraints.py`: both existing tests are reworked. They used attribute access on node objects, which no
  longer applies once plain values are bound, and `test_match_unless` passed only because its expression raised and
  the error was swallowed. The replacements exercise the documented subscript syntax and cover both the permitting and
  the refusing case for each option, so they distinguish a working constraint from one that does nothing.
- `README.md`: the closing paragraph of "Match Constraints" documented the asymmetry as a caveat and told readers to
  prefer `--match-unless`. That is now wrong. It is replaced with an `--match-if` example block (output produced by
  actually running the command) and an accurate description of the shared behavior.
- `graphtage/__main__.py`: the `--match-if` help text now says `from` and `to` are bound to plain Python values, and
  that a pair whose expression raises is left unconstrained. It also says "two nodes" rather than "two dictionaries",
  since the constraint applies to every node.

### On the log level

I left the swallowed errors at `log.debug` rather than raising them to a warning. Now that a raising expression is the
normal, expected path for every leaf node, a warning would fire on essentially every run and be noise rather than
signal. The README instead points at `--debug` for diagnosing a constraint that appears to have no effect, which I
verified prints the caught error for each skipped pair.

### Validation

```console
$ uv run --frozen --extra dev ruff check graphtage test docs bindist
All checks passed!

$ uv run --frozen --extra dev pytest
145 passed in 32.92s

$ uv run --frozen --extra dev make -C docs html SPHINXOPTS="-W --keep-going"
build succeeded.
```

`uv lock --check` reports the lockfile needs updating, but that reproduces on an unmodified tree — it is caused by a
resolver date pin in my environment ("Resolving despite existing lockfile due to addition of global exclude newer"),
not by this branch. No dependency files are touched.

The tests were verified to catch the bug rather than merely pass:

| `graphtage/constraints.py` state | `pytest test/test_constraints.py` |
| --- | --- |
| unmodified (`master`) | 3 failed, 4 passed |
| `to_obj()` binding only | 1 failed, 6 passed |
| `return None` on exception only | 2 failed, 5 passed |
| both changes (this branch) | 7 passed |

Each half of the fix in isolation still leaves a failing test, which is what establishes that both are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa
