### PR TITLE
Stop printing a replacement twice inside a list

### DIFF
--- a/docs/printing.rst
+++ b/docs/printing.rst
@@ -11,8 +11,8 @@ The protocol for delegating how a :class:`graphtage.TreeNode` or :class:`graphta
         * If ``with_edits``, then choose the edit
         * Otherwise, choose :attr:`node_or_edit.from_node <graphtage.Edit.from_node>`
     * If ``node_or_edit`` is a :class:`graphtage.TreeNode`:
-        * If ``with_edits`` *and* the node is edited and has a non-zero cost,
-            then choose :attr:`node_or_edit.edit <graphtage.EditedTreeNode.edit>`::
+        * If ``with_edits``, the node's own formatter is not already on the stack, *and* the node is edited and has a
+            non-zero cost, then choose :attr:`node_or_edit.edit <graphtage.EditedTreeNode.edit>`::
 
                 isinstance(node_or_edit, EditedTreeNode) and \
                         node_or_edit.edit is not None and node_or_edit.edit.has_non_zero_cost()
@@ -29,6 +29,7 @@ The protocol for delegating how a :class:`graphtage.TreeNode` or :class:`graphta
     * If not, try calling the edit's :func:`graphtage.Edit.print` method. If :exc:`NotImplementedError` is
       *not* raised, return.
 #. If the chosen object is a node, or if we failed to find a printer for the edit:
+    * Record that this node's formatter is on the stack, for the duration of the next two steps.
     * See if there is a specialized formatter for this node by calling
       :meth:`graphtage.formatter.Formatter.get_formatter`
     * If so, delegate to that formatter and return.
@@ -37,6 +38,20 @@ The protocol for delegating how a :class:`graphtage.TreeNode` or :class:`graphta
 
 This is implemented in :meth:`graphtage.GraphtageFormatter.print`. See the :ref:`Formatting Protocol` for how formatters
 are chosen.
+
+Re-entering the protocol with the same node
+-------------------------------------------
+
+``with_edits`` is an argument to :meth:`graphtage.GraphtageFormatter.print`, but it is not part of the
+``print_<NodeType>(printer, node)`` calling convention that formatters implement, so it stops at the formatter
+boundary. That matters because formatters hand nodes back to the protocol: a list formatter that meets a nested dict
+has no ``print_MappingNode`` of its own, so it calls ``self.parent.print(printer, node)`` to reach the format's dict
+formatter, as :meth:`graphtage.json.JSONListFormatter.print_SequenceNode` does. Such a call starts the protocol over
+for a node whose edit the outer call has already printed, or has deliberately declined to print.
+
+Recording the node for the duration of its own formatter is what keeps that second pass from printing the edit again.
+It applies to the node being printed only, not to its children, so an edit nested inside the delegated subtree still
+prints normally.
 
 Status Output
 -------------

--- a/graphtage/tree.py
+++ b/graphtage/tree.py
@@ -22,6 +22,20 @@ log = logging.getLogger(__name__)
 FormatterType = Formatter[Union['TreeNode', 'Edit']]
 
 
+_NODES_BEING_PRINTED: set[int] = set()
+"""The :func:`id` of every node whose formatter is currently on the stack.
+
+:meth:`GraphtageFormatter.print` decides whether to print a node's edit *before* it hands the node to that node's
+formatter, so by the time the formatter runs, the decision has already been made and acted upon. Formatters routinely
+re-enter :meth:`GraphtageFormatter.print` with the very same node to pass it to a sibling formatter, for example
+:meth:`graphtage.json.JSONListFormatter.print_SequenceNode`, which forwards a dict nested in a list to
+:class:`graphtage.json.JSONDictFormatter` through ``self.parent.print(...)``. That re-entry cannot repeat the
+decision: the ``with_edits`` argument is not part of the ``print_*`` calling convention, so it never reaches the
+sub-formatter and the re-entry would default to printing the edit a second time.
+
+"""
+
+
 class GraphtageFormatter(FormatterType):
     """A base class for defining formatters that operate on :class:`TreeNode` and :class:`Edit`."""
 
@@ -31,7 +45,9 @@ class GraphtageFormatter(FormatterType):
         Args:
             printer: The printer to which to write.
             node_or_edit: The node or edit to print.
-            with_edits: If :keyword:True, print any edits associated with the node.
+            with_edits: If :keyword:True, print any edits associated with the node. This is also implied to be
+                :keyword:False while the node's own formatter is on the stack, so that a formatter delegating the
+                same node to a sibling formatter does not print its edit twice.
 
         Note:
             The protocol for determining how a node or edit should be printed is very complex due to its extensibility.
@@ -44,7 +60,7 @@ class GraphtageFormatter(FormatterType):
             else:
                 edit: Edit | None = None
             node: TreeNode = node_or_edit.from_node
-        elif with_edits:
+        elif with_edits and id(node_or_edit) not in _NODES_BEING_PRINTED:
             if isinstance(node_or_edit, EditedTreeNode) and \
                     node_or_edit.edit is not None and node_or_edit.edit.has_non_zero_cost():
                 edit: Edit | None = node_or_edit.edit
@@ -66,14 +82,35 @@ class GraphtageFormatter(FormatterType):
                 return
             except NotImplementedError:
                 pass
-        formatter = self.get_formatter(node)
-        if formatter is not None:
-            formatter(printer, node)
-        else:
-            log.debug(f"""There is no formatter that can handle nodes of type {node.__class__.__name__}
+        self._print_node(printer, node)
+
+    def _print_node(self, printer: Printer, node: 'TreeNode'):
+        """Hands a node to its formatter, suppressing that node's edit for the duration of the call.
+
+        Whether to print ``node``'s edit was already settled by :meth:`GraphtageFormatter.print`, so any re-entrant
+        call for the same node must print the bare node. See :data:`_NODES_BEING_PRINTED`.
+
+        Args:
+            printer: The printer to which to write.
+            node: The node to print.
+
+        """
+        node_id = id(node)
+        is_outermost = node_id not in _NODES_BEING_PRINTED
+        if is_outermost:
+            _NODES_BEING_PRINTED.add(node_id)
+        try:
+            formatter = self.get_formatter(node)
+            if formatter is not None:
+                formatter(printer, node)
+            else:
+                log.debug(f"""There is no formatter that can handle nodes of type {node.__class__.__name__}
     Falling back to the node's internal printer
     Registered formatters: {''.join([f.__class__.__name__ for f in FORMATTERS])}""")
-            node.print(printer)
+                node.print(printer)
+        finally:
+            if is_outermost:
+                _NODES_BEING_PRINTED.discard(node_id)
 
 
 @runtime_checkable

--- a/test/test_issue_152.py
+++ b/test/test_issue_152.py
@@ -1,0 +1,69 @@
+from io import StringIO
+from typing import Any
+from unittest import TestCase
+
+import graphtage
+from graphtage import json as graphtage_json
+from graphtage.printer import Printer
+from graphtage.pydiff import print_diff
+
+REPLACEMENT_IN_A_LIST: tuple[Any, Any] = ([1, {"a": 1}], [1, [2, 3]])
+"""A dict nested in a list, replaced by a list.
+
+Rendering the replaced dict needs a formatter that the enclosing list formatter does not provide, so the list
+formatter hands the node back to the format's root formatter. That hand-off is what printed the replacement twice.
+
+"""
+
+REPLACEMENT_IN_A_DICT: tuple[Any, Any] = ({"k": {"a": 1}}, {"k": [2, 3]})
+"""The same replacement as a dict value, which never took the delegating path and always rendered correctly."""
+
+DELEGATING_TYPENAMES = ("json", "json5", "yaml", "toml", "ini")
+"""The filetypes whose list and dict formatters delegate to each other through ``self.parent.print(...)``."""
+
+TYPENAMES_THAT_RENDER_A_REPLACED_DICT_VALUE = ("json", "json5", "yaml", "ini")
+""":data:`DELEGATING_TYPENAMES` minus TOML, which writes a replaced table value as the original table and no edit."""
+
+
+class TestIssue152(TestCase):
+    """Reproduces https://github.com/trailofbits/graphtage/issues/152"""
+
+    @staticmethod
+    def render(from_obj: Any, to_obj: Any, typename: str) -> str:
+        """Returns the diff of two Python objects as rendered by the default formatter for ``typename``."""
+        from_tree = graphtage_json.build_tree(from_obj)
+        to_tree = graphtage_json.build_tree(to_obj)
+        formatter = graphtage.FILETYPES_BY_TYPENAME[typename].get_default_formatter()
+        stream = StringIO()
+        printer = Printer(out_stream=stream, ansi_color=False, quiet=True)
+        with printer:
+            formatter.print(printer, from_tree.diff(to_tree))
+        return stream.getvalue()
+
+    def test_json_prints_a_replacement_in_a_list_once(self):
+        self.assertEqual(
+            '[\n    1,\n    {\n        "a": 1\n    } -> [\n        2,\n        3\n    ]\n]',
+            self.render(*REPLACEMENT_IN_A_LIST, "json"),
+        )
+
+    def test_pydiff_prints_a_replacement_in_a_list_once(self):
+        """Renders the exact reproducer from the issue."""
+        stream = StringIO()
+        printer = Printer(out_stream=stream, ansi_color=False, quiet=True)
+        with printer:
+            print_diff(*REPLACEMENT_IN_A_LIST, printer=printer)
+        self.assertEqual('[1,{"a": 1} -> [2,3]]', stream.getvalue())
+
+    def test_delegating_formats_print_a_replacement_in_a_list_once(self):
+        """Every format whose list formatter delegates to a sibling formatter shared the same defect."""
+        for typename in DELEGATING_TYPENAMES:
+            with self.subTest(typename=typename):
+                rendered = self.render(*REPLACEMENT_IN_A_LIST, typename)
+                self.assertEqual(1, rendered.count(" -> "), f"printed more than one replacement: {rendered!r}")
+
+    def test_delegating_formats_print_a_replacement_in_a_dict_once(self):
+        """The control case from the issue: a replaced dict value was always rendered correctly."""
+        for typename in TYPENAMES_THAT_RENDER_A_REPLACED_DICT_VALUE:
+            with self.subTest(typename=typename):
+                rendered = self.render(*REPLACEMENT_IN_A_DICT, typename)
+                self.assertEqual(1, rendered.count(" -> "), f"printed more than one replacement: {rendered!r}")


### PR DESCRIPTION
Closes #152

## Root cause

`GraphtageFormatter.print` accepts a `with_edits` flag, but `with_edits` is not part of the
`print_<NodeType>(printer, node)` calling convention that every formatter implements, so the flag stops at the
formatter boundary (`graphtage/tree.py`, the `formatter(printer, node)` dispatch).

That matters because formatters routinely hand a node back to the protocol. `JSONListFormatter` has no
`print_MappingNode`, so a dict nested in a list falls through to its `print_SequenceNode`, which calls
`self.parent.print(printer, node)` to reach `JSONDictFormatter`. The re-entrant call defaults to `with_edits=True`,
finds the node's `Replace` still attached with a non-zero cost, and prints the whole edit a second time:

```
sequences.py  print_SequenceNode -> edit_print -> tree.py -> Replace.print
  edits.py    formatter.print(printer, self.from_node, False)
    tree.py   formatter(printer, node)          <-- with_edits=False is lost here
      json.py self.parent.print(printer, node)  <-- restarts with with_edits=True
        tree.py -> Replace.print AGAIN
```

A replaced dict *value* was never affected: it reaches `JSONDictFormatter.print_MappingNode` through
`print_KeyValuePairNode`, which calls `super().print_SequenceNode` instead of re-entering `.print()`.

## The fix

`GraphtageFormatter.print` now records the node while that node's own formatter is on the stack, and treats a
re-entrant call for the same node as `with_edits=False`. The decision about a node's edit is made once, by the
outermost call — which is the invariant the delegating formatters already assumed. The dispatch moved into a small
`_print_node` helper so the record is released in a `finally`.

I chose the re-entrancy guard over threading `with_edits` through the dispatch. Threading it would require adding a
`with_edits` parameter to every `print_*` method in the package: the delegating methods are written as
`def print_SequenceNode(self, *args, **kwargs)` and forward `**kwargs` straight into implementations such as
`SequenceFormatter.print_SequenceNode(self, printer, node)` and `JSONListFormatter.print_ListNode`, which would raise
`TypeError` on the extra keyword. Signature inspection at the dispatch site would guess wrong for exactly those
forwarding methods. The guard is central to `tree.py`, changes no formatter signature, and leaves
`graphtage/json.py` untouched for the parallel work on #158.

The guard covers only the node being printed, not its children, so an edit nested inside a delegated subtree still
prints normally. `docs/printing.rst` documents this protocol and is updated to match.

## Formats affected

Reproduced before the fix and correct after it:

| Format | Before | After |
| --- | --- | --- |
| JSON | `[1,{"a": 1} -> [2,3] -> [2,3]]` | `[1,{"a": 1} -> [2,3]]` |
| JSON5 | duplicated | one replacement |
| YAML | `- a: 1 -> \n  - 2\n  - 3 -> \n  - 2\n  - 3` | `- a: 1 -> \n  - 2\n  - 3` |
| TOML | `[1,a = 1\n\n   -> [2,3] -> [2,3]]` | `[1,a = 1\n\n   -> [2,3]]` |
| INI | `1,a = 1\n -> 2,3 -> 2,3` | `1,a = 1\n -> 2,3` |

plist and XML never delegate across container types (`PLISTSequenceFormatter` defines both `print_ListNode` and
`print_MultiSetNode`; `graphtage/xml.py` has no `self.parent.print` call), so they were already correct and stay
correct.

`Insert` and `Remove` did not duplicate, because neither attaches itself to `EditedTreeNode.edit`; only `Replace`
and `Match` leave a non-zero-cost edit on the node that the re-entrant call could find.

## Validation

New regression test `test/test_issue_152.py`:

* the exact `print_diff([1, {"a": 1}], [1, [2, 3]])` reproducer from the issue,
* the full JSON rendering of the same diff,
* a sweep over `json`, `json5`, `yaml`, `toml`, and `ini` asserting exactly one replacement arrow,
* the control case from the issue, a replaced dict value, over the formats that render one.

Verified the tests catch the bug: run against the unpatched `graphtage/tree.py`, 2 tests and 5 subtests fail with
`'[1,{"a": 1} -> [2,3]]' != '[1,{"a": 1} -> [2,3] -> [2,3]]'` and `1 != 2` arrows for each of the five formats; with
the fix, all pass. The dict-value control passes in both states, confirming it isolates the delegating path.

The control sweep skips TOML, which renders a replaced table value as the original table with no edit at all. That is
a separate, pre-existing defect: it behaves identically on unmodified `master` and is unchanged by this PR.

Local CI:

* `ruff check graphtage test docs bindist` — all checks passed
* `pytest` — 144 passed, 9 subtests passed
* `pytest test/test_formatting.py` — 15 passed. This is the main safety net for a change to the printing protocol:
  1000 fuzz round-trip iterations each for JSON, CSV, YAML, and plist, 250 for XML, and 200 each for TOML and INI,
  plus the JSON5, HTML, and pickle round-trips
* `make -C docs html SPHINXOPTS="-W --keep-going"` — build succeeded
* `uv lock --check` — fails identically on unmodified `origin/master` in this environment because of a global
  `exclude-newer` setting; neither `pyproject.toml` nor `uv.lock` is touched by this PR

Also spot-checked by hand: two sibling replacements in one list, a replacement three levels deep, a replacement
alongside a string edit, and the HTML printer — all render a single replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa
