### PR TITLE
Fix DataClassNode slot accumulation under multiple inheritance

### DIFF
--- a/graphtage/dataclasses.py
+++ b/graphtage/dataclasses.py
@@ -120,11 +120,13 @@ class DataClassNode(ContainerNode):
             for a in ancestors
             for name in a._SLOTS
         }
-        if not hasattr(cls, "_SLOT_ANNOTATIONS") or cls._SLOT_ANNOTATIONS is None:
-            cls._SLOT_ANNOTATIONS = {}
-            cls._SLOTS = ()
-        else:
-            cls._SLOT_ANNOTATIONS = dict(cls._SLOT_ANNOTATIONS)
+        # Collect the inherited slots from *all* data-class ancestors, in reverse-MRO order.
+        # Reading the inherited `_SLOT_ANNOTATIONS`/`_SLOTS` attributes instead would follow
+        # only the first inheritance chain, silently dropping the slots of any additional bases.
+        inherited_slot_annotations: dict[str, type[TreeNode]] = {}
+        for ancestor in reversed(ancestors):
+            inherited_slot_annotations.update(ancestor._SLOT_ANNOTATIONS)
+        cls._SLOT_ANNOTATIONS = inherited_slot_annotations
         new_slots = []
         for name, slot_type in cls.__annotations__.items():
             # get_origin() screens out subscripted generics before issubclass() sees them. On Python
@@ -138,7 +140,7 @@ class DataClassNode(ContainerNode):
                                 f"defined in its superclass {ancestor_slot_names[name].__name__}")
             new_slots.append(name)
             cls._SLOT_ANNOTATIONS[name] = slot_type
-        cls._SLOTS = cls._SLOTS + tuple(new_slots)
+        cls._SLOTS = tuple(cls._SLOT_ANNOTATIONS)
 
     def __hash__(self):
         return self.__hash

--- a/test/test_dataclasses.py
+++ b/test/test_dataclasses.py
@@ -91,6 +91,41 @@ class TestDataclasses(TestCase):
                 self.name.quoted = False
 
         self.assertFalse(Unquoted(StringNode("name")).name.quoted)
+
+    def test_multiple_inheritance(self):
+        """Slots from *all* bases must survive diamond inheritance, not just the first chain."""
+        class Foo(DataClassNode):
+            foo: IntegerNode
+
+        class Bar(Foo):
+            bar: StringNode
+
+        class Baz(Foo):
+            baz: StringNode
+
+        class Quux(Bar, Baz):
+            quux: IntegerNode
+
+        self.assertEqual(("foo",), Foo._SLOTS)
+        self.assertEqual(("foo", "bar"), Bar._SLOTS)
+        self.assertEqual(("foo", "baz"), Baz._SLOTS)
+        self.assertEqual(("foo", "baz", "bar", "quux"), Quux._SLOTS)
+        self.assertEqual(
+            {"foo": IntegerNode, "baz": StringNode, "bar": StringNode, "quux": IntegerNode},
+            Quux._SLOT_ANNOTATIONS
+        )
+
+        node = Quux(foo=IntegerNode(1), bar=StringNode("bar"), baz=StringNode("baz"), quux=IntegerNode(4))
+        self.assertEqual(1, node.foo.object)
+        self.assertEqual("bar", node.bar.object)
+        self.assertEqual("baz", node.baz.object)
+        self.assertEqual(4, node.quux.object)
+        self.assertEqual({"foo", "bar", "baz", "quux"}, set(node.to_obj()))
+
+        # diffing against an identical node yields a DataClassEdit, not a Replace
+        twin = Quux(foo=IntegerNode(1), bar=StringNode("bar"), baz=StringNode("baz"), quux=IntegerNode(4))
+        self.assertIsInstance(node.edits(twin), DataClassEdit)
+
     def test_print_renders_slots(self):
         """:meth:`DataClassNode.print` is the fallback when no formatter resolves the node type."""
         class Foo(DataClassNode):


### PR DESCRIPTION
Fixes #173.

`DataClassNode.__init_subclass__` accumulated slots from the inherited `_SLOTS` / `_SLOT_ANNOTATIONS` attributes, which resolve through the MRO to only the **first** inheritance chain. With diamond inheritance (`class D(B, C)`), the slots of every base after the first were silently dropped: `D._SLOTS` came out as `('a', 'b', 'd')` instead of `('a', 'c', 'b', 'd')`, so `items()`, `__iter__`, `to_obj()` and the hash all ignored the second base — and constructing `D` failed with a misleading `TypeError: object.__init__() takes exactly one argument`.

This change collects slot annotations from *all* data-class ancestors in reverse-MRO order (the approach sketched in #173) and derives `_SLOTS` from the merged annotations, so a class can no longer lose the slots of its additional bases.

## Testing

- Added a `test_multiple_inheritance` regression test covering `_SLOTS` / `_SLOT_ANNOTATIONS` order, construction, `to_obj()`, and diffing two diamond-inherited nodes.
- Full suite on this machine: **146 passed, 1 pre-existing failure** — `test_git.py::TestGitIntegration::test_git_accepts_the_driver` fails on unmodified `master` here as well (verified by stashing this change and re-running), so it is unrelated to this PR.

## Disclosure

This PR was generated by an AI coding agent operated by @Liyu0310-Code; the account owner does not review code. Happy to iterate on any feedback.
