### PR TITLE
Render import aliases without quotes

### DIFF
--- a/graphtage/pydiff.py
+++ b/graphtage/pydiff.py
@@ -120,8 +120,19 @@ ASTNode = ast.AST | ast.stmt | ast.expr | ast.alias
 
 
 class PyAlias(DataClassNode):
+    """An imported name and the alias it is bound to, as in ``import os as o``.
+
+    Both slots hold Python identifiers rather than string literals, so neither is quoted when printed. An empty
+    ``as_name`` means the import has no alias.
+    """
+
     name: StringNode
     as_name: StringNode
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name.quoted = False
+        self.as_name.quoted = False
 
     def print(self, printer: Printer):
         self.name.print(printer)
@@ -235,9 +246,9 @@ class ASTBuilder(BasicBuilder):
     @Builder.builder(ast.alias)
     def build_alias(self, node: ast.alias, _):
         if not node.asname:
-            as_name = StringNode("")
+            as_name = StringNode("", quoted=False)
         else:
-            as_name = StringNode(node.asname)
+            as_name = StringNode(node.asname, quoted=False)
         return PyAlias(StringNode(node.name, quoted=False), as_name)
 
     @Builder.builder(ast.Attribute)

--- a/test/test_pydiff.py
+++ b/test/test_pydiff.py
@@ -73,6 +73,43 @@ class TestPyDiff(TestCase):
         for source in ("import os", "import os.path", "import os, sys", "from os import path"):
             with self.subTest(source=source):
                 self.assertEqual(f"{source}\n", format_tree(ast_to_tree(ast.parse(source))))
+
+    def test_import_alias_is_not_quoted(self):
+        """Reproduces https://github.com/trailofbits/graphtage/issues/172
+
+        `PyAlias` built its `as_name` with `StringNode`'s default quoting, so `from os import path as p` rendered as
+        `from os import path as "p"`. Both printing paths write the slot as-is, so both quoted the alias:
+        `PyDiffFormatter.print_PyAlias` and `PyAlias.print`.
+        """
+        expected = {
+            "from os import path": ["path"],
+            "from os import path as p": ["path as p"],
+            "from a import b as c, d as e": ["b as c", "d as e"],
+            "import os as o": ["os as o"],
+        }
+        for source, alias_renderings in expected.items():
+            with self.subTest(source=source):
+                tree = ast_to_tree(ast.parse(source))
+                self.assertEqual(f"{source}\n", format_tree(tree))
+                aliases = [node for node in tree.dfs() if isinstance(node, PyAlias)]
+                for alias, rendering in zip(aliases, alias_renderings, strict=True):
+                    stream = StringIO()
+                    alias.print(Printer(out_stream=stream, ansi_color=False))
+                    self.assertEqual(rendering, stream.getvalue())
+
+    def test_directly_constructed_alias_is_not_quoted(self):
+        """`PyAlias` un-quotes its own slots, just as `PyObjAttribute` does, so callers need not pass `quoted`."""
+        stream = StringIO()
+        alias = PyAlias(graphtage.StringNode("os"), graphtage.StringNode("o"))
+
+        alias.print(Printer(out_stream=stream, ansi_color=False))
+
+        self.assertEqual("os as o", stream.getvalue())
+
+    def test_alias_edit_is_not_quoted(self):
+        """An edited alias must stay unquoted too; the diff used to render as `import os as "o" -> "p"`."""
+        self.assertEqual("import os as o -> p", render_diff("import os as o", "import os as p"))
+
     def test_attribute_receiver_is_not_quoted(self):
         stream = StringIO()
         attribute = PyObjAttribute(graphtage.StringNode("package"), graphtage.StringNode("member"))


### PR DESCRIPTION
Closes #172

`ASTBuilder.build_alias` built the `as_name` slot of `PyAlias` with `StringNode`'s default quoting, so
`from os import path as p` rendered as `from os import path as "p"`. An alias is a Python identifier, not a string
literal, and the module name and imported name beside it were already built unquoted. Both printing paths write the
slot as-is, so `PyAlias.print` and `PyDiffFormatter.print_PyAlias` quoted the alias alike, as did the rendering of an
edit to an alias (`import os as "o" -> "p"`).

`PyAlias` now clears `quoted` on both of its slots in `__init__`, the same way its neighbors `Call`, `Import`, and
`PyObjAttribute` do, so aliases constructed outside the AST builder are covered too. The empty-string `as_name` that
means "no alias" still works: both printers branch on it, and neither prints it.

No other identifier-valued `StringNode` in `ASTBuilder` has the same omission. `build_name`, `build_import_from`,
`build_import`, the `name` slot of `build_alias`, and `build_attribute` all pass `quoted=False` already;
`BasicBuilder.build_str` quotes by design, because it builds real string literals.

## Validation

- New tests in `test/test_pydiff.py` cover both printing paths, direct construction, an edited alias, and the
  no-alias case. Run against the unfixed code they fail (`'import os as o\n' != 'import os as \"o\"\n'`, and the
  matching failures for the other cases); with the fix they pass. The `from os import path` subtest passes either
  way, which is what guards the empty-alias sentinel.
- `uv run --frozen --extra dev ruff check graphtage test docs bindist` — passes.
- `uv run --frozen --extra dev pytest` — 177 passed, 23 subtests passed.
- `uv run --frozen --extra dev make -C docs html SPHINXOPTS="-W --keep-going"` — build succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa