### PR TITLE
Render a replaced TOML table inline instead of dropping it

### DIFF
--- a/graphtage/toml.py
+++ b/graphtage/toml.py
@@ -6,10 +6,11 @@ from typing import Optional
 import toml
 
 from . import json
+from .edits import Replace
 from .graphtage import BuildOptions, Filetype, KeyValuePairNode, LeafNode, MappingNode, StringFormatter, StringNode
 from .printer import Printer
 from .sequences import SequenceFormatter
-from .tree import GraphtageFormatter, TreeNode
+from .tree import EditedTreeNode, GraphtageFormatter, TreeNode
 
 
 def build_tree(path: str, options: BuildOptions | None) -> TreeNode:
@@ -53,9 +54,8 @@ class TOMLListFormatter(SequenceFormatter):
 
             self.parent.print(*args, **kwargs)
 
-        which should invoke :meth:`TOMLFormatter.print`, thereby delegating to the :class:`TOMLDictFormatter` in
-        instances where a list contains a dict (the TOML format doesn't allow this, but it might be necessary if
-        formatting from another format into TOML)
+        which should invoke :meth:`TOMLFormatter.print`, thereby delegating to the
+        :class:`TOMLInlineTableFormatter` in instances where a list contains a dict.
 
         """
         self.parent.print(*args, **kwargs)
@@ -82,6 +82,89 @@ class TOMLStringFormatter(StringFormatter):
             return s
 
 
+class TOMLInlineTableFormatter(SequenceFormatter):
+    """A sub-formatter for mappings that have nowhere to write a ``[table]`` header.
+
+    A mapping only gets a header when it is reached by walking down from the document root. One that appears in a
+    value position has no such header available: the replaced side of an edit is printed inside the ``key = value``
+    line it belongs to, and a mapping nested in a list is printed inside the list. Both are written as TOML inline
+    tables, ``{key = value, ...}``, so that the value stays attached to its key.
+
+    """
+    is_partial = True
+
+    def __init__(self):
+        """Initializes the TOML inline table formatter.
+
+        Equivalent to::
+
+            super().__init__('{', '}', ',')
+
+        """
+        super().__init__('{', '}', ',')
+
+    def item_newline(self, printer: Printer, is_first: bool = False, is_last: bool = False):
+        """Separates two entries with a single space, since an inline table is written on one line."""
+        if not is_first and not is_last:
+            printer.write(' ')
+
+    def items_indent(self, printer: Printer) -> Printer:
+        """Returns :obj:`printer` itself, since an inline table writes no newline for an indent to apply to."""
+        return printer
+
+    def print_MappingNode(self, *args, **kwargs):
+        """Prints a :class:`graphtage.MappingNode`.
+
+        Equivalent to::
+
+            super().print_SequenceNode(*args, **kwargs)
+
+        """
+        super().print_SequenceNode(*args, **kwargs)
+
+    def print_KeyValuePairNode(self, printer: Printer, node: KeyValuePairNode):
+        """Prints one entry of an inline table.
+
+        This is :meth:`TOMLFormatter.write_key_value_pair` without the newline that ends a top-level
+        ``key = value`` line, which would otherwise break the inline table across lines.
+
+        """
+        self.parent.write_key_value_pair(printer, node)
+
+    def print_SequenceNode(self, *args, **kwargs):
+        """Prints a non-mapping sequence.
+
+        This delegates to the parent formatter's implementation::
+
+            self.parent.print(*args, **kwargs)
+
+        which should invoke :meth:`TOMLFormatter.print`, thereby delegating to the :class:`TOMLListFormatter` in
+        instances where an inline table contains a list.
+
+        """
+        self.parent.print(*args, **kwargs)
+
+
+def is_table(kvp: KeyValuePairNode) -> bool:
+    """Returns whether a key/value pair is written as a ``[table]`` section rather than as ``key = value``.
+
+    Only a pair whose value is a mapping can have a section of its own, and only if no edit replaces that mapping
+    with a value of another type. A section body has nowhere to write such a replacement, so classifying the pair as
+    a section would drop its edit from the output entirely.
+
+    Args:
+        kvp: The key/value pair to classify.
+
+    Returns:
+        bool: :const:`True` if :obj:`kvp` is written as its own ``[table]`` section, and :const:`False` if it is
+        written inline as ``key = value``.
+
+    """
+    if not isinstance(kvp.value, MappingNode):
+        return False
+    return not (isinstance(kvp.value, EditedTreeNode) and isinstance(kvp.value.edit, Replace))
+
+
 class TOMLMapping:
     def __init__(
             self,
@@ -100,12 +183,16 @@ class TOMLMapping:
         else:
             return (*self.parent.name_segments, self.parent_name)
 
-    def items(self) -> Iterator[KeyValuePairNode]:
+    def key_value_pairs(self) -> Iterator[KeyValuePairNode]:
+        """Iterates over this mapping's key/value pairs, including any that an edit inserts into it."""
         inserted = ()
         if self.mapping.edited and self.mapping.inserted:
             inserted = self.mapping.inserted
-        for kvp in itertools.chain(self.mapping, inserted):
-            if not isinstance(kvp.value, MappingNode):
+        return itertools.chain(self.mapping, inserted)
+
+    def items(self) -> Iterator[KeyValuePairNode]:
+        for kvp in self.key_value_pairs():
+            if not is_table(kvp):
                 yield kvp
 
     def __bool__(self):
@@ -120,16 +207,23 @@ class TOMLMapping:
                 return True
 
     def children(self) -> Iterator['TOMLMapping']:
-        inserted = ()
-        if self.mapping.edited and self.mapping.inserted:
-            inserted = self.mapping.inserted
-        for kvp in itertools.chain(self.mapping, inserted):
-            if isinstance(kvp.value, MappingNode):
+        for kvp in self.key_value_pairs():
+            if is_table(kvp):
                 yield TOMLMapping(mapping=kvp.value, parent=self, parent_name=kvp.key)
 
 
 class TOMLFormatter(GraphtageFormatter):
-    sub_format_types = (TOMLListFormatter, TOMLStringFormatter)
+    sub_format_types = (TOMLListFormatter, TOMLStringFormatter, TOMLInlineTableFormatter)
+
+    @property
+    def inline_tables(self) -> TOMLInlineTableFormatter:
+        """The sub-formatter for a mapping that has nowhere to write a ``[table]`` header.
+
+        The :ref:`Formatting Protocol` resolves a formatter from a node's type alone, and a mapping written as a
+        section and a mapping written inline are the same type, so this formatter selects between the two itself.
+
+        """
+        return next(f for f in self.sub_formatters if isinstance(f, TOMLInlineTableFormatter))
 
     def print(self, printer: Printer, *args, **kwargs):
         # TOML has optional indentation; make it only two spaces, if we use it:
@@ -139,7 +233,14 @@ class TOMLFormatter(GraphtageFormatter):
     def print_LeafNode(self, printer: Printer, node: LeafNode):
         printer.write(toml_dumps(node.object))
 
-    def print_KeyValuePairNode(self, printer: Printer, node: KeyValuePairNode):
+    def write_key_value_pair(self, printer: Printer, node: KeyValuePairNode):
+        """Writes ``key = value``, without the newline that ends a line of a table body.
+
+        Args:
+            printer: The printer to which to write.
+            node: The key/value pair to write.
+
+        """
         if isinstance(node.key, StringNode):
             node.key.quoted = False
         self.print(printer, node.key)
@@ -147,9 +248,16 @@ class TOMLFormatter(GraphtageFormatter):
         if isinstance(node.value, StringNode):
             node.value.quoted = True
         self.print(printer, node.value)
+
+    def print_KeyValuePairNode(self, printer: Printer, node: KeyValuePairNode):
+        self.write_key_value_pair(printer, node)
         printer.newline()
 
     def print_MappingNode(self, printer: Printer, node: MappingNode):
+        if node.parent is not None:
+            # This mapping is a value rather than the document, so there is no header to write it under:
+            self.inline_tables.print_MappingNode(printer, node)
+            return
         mappings = [TOMLMapping(node)]
         while mappings:
             m: TOMLMapping = mappings.pop()

--- a/test/test_toml.py
+++ b/test/test_toml.py
@@ -1,0 +1,86 @@
+from io import StringIO
+from unittest import TestCase
+
+import graphtage
+from graphtage.printer import Printer
+from graphtage.utils import Tempfile
+
+TABLE = b"""[k]
+a = 1
+"""
+
+EDITED_TABLE = b"""[k]
+a = 2
+"""
+
+LIST_VALUE = b"""k = [2, 3]
+"""
+
+SCALAR_ONE = b"""k = 1
+"""
+
+SCALAR_TWO = b"""k = 2
+"""
+
+NESTED_TABLE = b"""[outer.k]
+a = 1
+"""
+
+NESTED_LIST_VALUE = b"""[outer]
+k = [2, 3]
+"""
+
+
+def build(content: bytes) -> graphtage.TreeNode:
+    with Tempfile(content) as path:
+        return graphtage.FILETYPES_BY_TYPENAME["toml"].build_tree(path)
+
+
+def render(node: graphtage.TreeNode) -> str:
+    stream = StringIO()
+    printer = Printer(out_stream=stream, ansi_color=False)
+    graphtage.FILETYPES_BY_TYPENAME["toml"].get_default_formatter().print(printer, node)
+    printer.flush(final=True)
+    return stream.getvalue()
+
+
+def render_diff(from_content: bytes, to_content: bytes) -> str:
+    return render(build(from_content).diff(build(to_content)))
+
+
+def diff_lines(from_content: bytes, to_content: bytes) -> list[str]:
+    """Returns the rendered diff as a list of lines, dropping the blank lines that separate tables."""
+    return [line for line in render_diff(from_content, to_content).splitlines() if line.strip()]
+
+
+class TestTOMLDiff(TestCase):
+    """Covers the diff path, which ``@filetype_test`` cannot reach because it only round-trips unedited trees."""
+
+    def test_table_replaced_by_a_list_is_marked(self):
+        """A table replaced by a value of another type used to render byte-identically to no change at all."""
+        self.assertNotEqual(diff_lines(TABLE, TABLE), diff_lines(TABLE, LIST_VALUE))
+        self.assertEqual(["k = {a = 1} -> [2,3]"], diff_lines(TABLE, LIST_VALUE))
+
+    def test_table_replacing_a_list_keeps_its_key(self):
+        """The replacement used to be written as a headerless table body, orphaning ``a = 1`` from its ``k``."""
+        self.assertEqual(["k = [2,3] -> {a = 1}"], diff_lines(LIST_VALUE, TABLE))
+
+    def test_nested_table_replaced_by_a_list_is_marked(self):
+        """A replaced table below the document root is written inline under the table that contains it."""
+        self.assertEqual(["[outer]", "k = {a = 1} -> [2,3]"], diff_lines(NESTED_TABLE, NESTED_LIST_VALUE))
+        self.assertEqual(["[outer]", "k = [2,3] -> {a = 1}"], diff_lines(NESTED_LIST_VALUE, NESTED_TABLE))
+
+    def test_replaced_scalar_is_marked(self):
+        """The control: a scalar replacement was never broken and must keep rendering as one line."""
+        self.assertEqual(["k = 1 -> 2"], diff_lines(SCALAR_ONE, SCALAR_TWO))
+
+    def test_table_that_is_not_replaced_keeps_its_header(self):
+        """A table whose value stays a table is still written as a ``[table]`` section rather than inline."""
+        self.assertEqual(["[k]", "a = 1 -> 2"], diff_lines(TABLE, EDITED_TABLE))
+
+    def test_unchanged_document_has_no_edit_markers(self):
+        unchanged = render_diff(TABLE, TABLE)
+        self.assertNotIn("->", unchanged)
+        self.assertNotIn("~~", unchanged)
+        self.assertNotIn("++", unchanged)
+        self.assertEqual(["[k]", "a = 1"], diff_lines(TABLE, TABLE))


### PR DESCRIPTION
Closes #174

## Root cause

`TOMLMapping` split a mapping's key/value pairs into `[table]` sections and inline `key = value` lines using a single
test: `isinstance(kvp.value, MappingNode)`. That looks only at the *from* side of the diff and ignores the value's edit
entirely, and everything else follows from it.

- **From side (the silent one).** `{"k": {"a": 1}}` against `{"k": [2, 3]}` gives the pair `k` an
  `EditedDictNode` value carrying a `Replace` edit to a `ListNode`. The value is still a `MappingNode`, so
  `TOMLMapping.children()` claimed the pair and `TOMLFormatter.print_MappingNode` wrote the section by walking the
  mapping's own children. The pair never went through `GraphtageFormatter.print`, so its `Replace` edit was never
  printed at all.
- **To side.** `{"k": [2, 3]}` against `{"k": {"a": 1}}` gives the pair an `EditedListNode` value, which is not a
  `MappingNode`, so it went to `items()` and printed as `k = <value>`. `Replace.print` then handed the replacement
  `DictNode` back to `print_MappingNode`, which built a fresh root `TOMLMapping` with no `name_segments` and wrote a
  headerless section body.

So the two defects share a root cause and are fixed together: the table/inline split ignored edits, and a mapping in a
value position had no rendering that keeps it attached to its key. The bug is entirely inside `graphtage/toml.py`; the
diff itself and the shared printing protocol are correct, and neither `graphtage/tree.py` nor `graphtage/sequences.py`
is touched.

## Fix

- `is_table()` classifies a pair as a section only when its value is a mapping *and* no edit replaces that mapping with
  a value of another type. A replaced pair therefore prints as a `key = value` line, which routes it through the
  printing protocol so its `Replace` edit is rendered.
- `TOMLInlineTableFormatter` writes a mapping that has nowhere to put a header as a TOML inline table,
  `{key = value, ...}`. `print_MappingNode` selects it when the mapping is not the document root
  (`node.parent is not None`); the Formatting Protocol resolves by node type alone and both renderings are the same
  type, so the formatter has to make that choice itself rather than registering a second `print_MappingNode` for the
  protocol to pick between.
- `TOMLMapping.key_value_pairs()` factors out the "children plus insertions" iteration that `items()` and
  `children()` had each duplicated.

## Before and after

```console
$ printf '[k]\na = 1\n' > a.toml
$ printf 'k = [2, 3]\n' > b.toml
```

| | before | after |
|---|---|---|
| `graphtage a.toml b.toml` | `[k]`<br>`a = 1` (no edit shown, exit 1) | `k = {a = 1} -> [2,3]` |
| `graphtage b.toml a.toml` | `k = [2,3] -> a = 1` | `k = [2,3] -> {a = 1}` |
| `graphtage c.toml d.toml` (scalar control) | `k = 1 -> 2` | `k = 1 -> 2` |

Rendering another format's list of mappings as TOML had no valid output before either, and is fixed by the same inline
table:

For `{"rows": [{"a": 1}, {"b": 2}]}` against `{"rows": [{"a": 1}, {"b": 3}]}`, `graphtage --format toml` used to print
this, which is not TOML:

```toml
rows = [a = 1

  ,b = 2 -> 3

]
```

and now prints:

```toml
rows = [{a = 1},{b = 2 -> 3}]
```

## Still broken, and out of scope

Inserting or removing a whole table renders with **no** edit markup, the same silent-wrong-answer class as this issue
but a different mechanism: `TOMLMapping.children()` writes the `[header]` and body directly, and there is no node for
`Remove.print` or `Insert.print` to wrap, so the marking would have to be applied to the header and body by the section
writer. `graphtage f.toml g.toml`, where `g.toml` adds a `[j]` table, prints `[j]` and its contents unmarked. That is
not one of the two defects #174 documents, and fixing it means changing how sections are emitted rather than how they
are classified, so it is left for separate work. Removing or inserting a *scalar* key inside a table is marked
correctly today and is unaffected.

## Validation

- `test/test_toml.py` is new, modelled on `test/test_ini.py`. Its three bug tests
  (`test_table_replaced_by_a_list_is_marked`, `test_table_replacing_a_list_keeps_its_key`,
  `test_nested_table_replaced_by_a_list_is_marked`) were confirmed to **fail** against unmodified `graphtage/toml.py`
  and to pass with the fix. Its three control tests (`test_replaced_scalar_is_marked`,
  `test_table_that_is_not_replaced_keeps_its_header`, `test_unchanged_document_has_no_edit_markers`) pass both before
  and after, so they pin down what the fix must not change.
- `uv run --frozen --extra dev ruff check graphtage test docs bindist` — clean.
- `uv run --frozen --extra dev pytest` — 180 passed, including `test_formatting.py`'s 200-iteration TOML round-trip
  fuzz, which is the regression net for unedited rendering.
- `uv run --frozen --extra dev make -C docs html SPHINXOPTS="-W --keep-going"` — build succeeded.
- Reproduced every command in the issue by hand before and after, plus the `--html` and ANSI color output paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa
