### PR TITLE
Keep every base's slots under multiple inheritance

### DIFF
--- a/graphtage/dataclasses.py
+++ b/graphtage/dataclasses.py
@@ -120,14 +120,14 @@ class DataClassNode(ContainerNode):
             for a in ancestors
             for name in a._SLOTS
         }
-        # Collect the inherited slots from *all* data-class ancestors, in reverse-MRO order.
-        # Reading the inherited `_SLOT_ANNOTATIONS`/`_SLOTS` attributes instead would follow
-        # only the first inheritance chain, silently dropping the slots of any additional bases.
+        # Collect the inherited slots from *all* data-class ancestors, which `ancestors` already
+        # lists base-first. Reading the inherited `_SLOT_ANNOTATIONS`/`_SLOTS` attributes instead
+        # would follow only the first inheritance chain, silently dropping the slots of any
+        # additional bases.
         inherited_slot_annotations: dict[str, type[TreeNode]] = {}
-        for ancestor in reversed(ancestors):
+        for ancestor in ancestors:
             inherited_slot_annotations.update(ancestor._SLOT_ANNOTATIONS)
         cls._SLOT_ANNOTATIONS = inherited_slot_annotations
-        new_slots = []
         for name, slot_type in cls.__annotations__.items():
             # get_origin() screens out subscripted generics before issubclass() sees them. On Python
             # 3.10 isinstance(list[int], type) is True, so issubclass() would raise there.
@@ -138,7 +138,6 @@ class DataClassNode(ContainerNode):
             if name in ancestor_slot_names:
                 raise TypeError(f"Dataclass {cls.__name__} cannot redefine slot {name!r} because it is already "
                                 f"defined in its superclass {ancestor_slot_names[name].__name__}")
-            new_slots.append(name)
             cls._SLOT_ANNOTATIONS[name] = slot_type
         cls._SLOTS = tuple(cls._SLOT_ANNOTATIONS)
 

--- a/graphtage/dataclasses.py
+++ b/graphtage/dataclasses.py
@@ -120,11 +120,13 @@ class DataClassNode(ContainerNode):
             for a in ancestors
             for name in a._SLOTS
         }
-        if not hasattr(cls, "_SLOT_ANNOTATIONS") or cls._SLOT_ANNOTATIONS is None:
-            cls._SLOT_ANNOTATIONS = {}
-            cls._SLOTS = ()
-        else:
-            cls._SLOT_ANNOTATIONS = dict(cls._SLOT_ANNOTATIONS)
+        # Collect the inherited slots from *all* data-class ancestors, in reverse-MRO order.
+        # Reading the inherited `_SLOT_ANNOTATIONS`/`_SLOTS` attributes instead would follow
+        # only the first inheritance chain, silently dropping the slots of any additional bases.
+        inherited_slot_annotations: dict[str, type[TreeNode]] = {}
+        for ancestor in reversed(ancestors):
+            inherited_slot_annotations.update(ancestor._SLOT_ANNOTATIONS)
+        cls._SLOT_ANNOTATIONS = inherited_slot_annotations
         new_slots = []
         for name, slot_type in cls.__annotations__.items():
             # get_origin() screens out subscripted generics before issubclass() sees them. On Python
@@ -138,7 +140,7 @@ class DataClassNode(ContainerNode):
                                 f"defined in its superclass {ancestor_slot_names[name].__name__}")
             new_slots.append(name)
             cls._SLOT_ANNOTATIONS[name] = slot_type
-        cls._SLOTS = cls._SLOTS + tuple(new_slots)
+        cls._SLOTS = tuple(cls._SLOT_ANNOTATIONS)
 
     def __hash__(self):
         return self.__hash

--- a/test/test_dataclasses.py
+++ b/test/test_dataclasses.py
@@ -91,6 +91,41 @@ class TestDataclasses(TestCase):
                 self.name.quoted = False
 
         self.assertFalse(Unquoted(StringNode("name")).name.quoted)
+
+    def test_multiple_inheritance(self):
+        """Slots from *all* bases must survive diamond inheritance, not just the first chain."""
+        class Foo(DataClassNode):
+            foo: IntegerNode
+
+        class Bar(Foo):
+            bar: StringNode
+
+        class Baz(Foo):
+            baz: StringNode
+
+        class Quux(Bar, Baz):
+            quux: IntegerNode
+
+        self.assertEqual(("foo",), Foo._SLOTS)
+        self.assertEqual(("foo", "bar"), Bar._SLOTS)
+        self.assertEqual(("foo", "baz"), Baz._SLOTS)
+        self.assertEqual(("foo", "baz", "bar", "quux"), Quux._SLOTS)
+        self.assertEqual(
+            {"foo": IntegerNode, "baz": StringNode, "bar": StringNode, "quux": IntegerNode},
+            Quux._SLOT_ANNOTATIONS
+        )
+
+        node = Quux(foo=IntegerNode(1), bar=StringNode("bar"), baz=StringNode("baz"), quux=IntegerNode(4))
+        self.assertEqual(1, node.foo.object)
+        self.assertEqual("bar", node.bar.object)
+        self.assertEqual("baz", node.baz.object)
+        self.assertEqual(4, node.quux.object)
+        self.assertEqual({"foo", "bar", "baz", "quux"}, set(node.to_obj()))
+
+        # diffing against an identical node yields a DataClassEdit, not a Replace
+        twin = Quux(foo=IntegerNode(1), bar=StringNode("bar"), baz=StringNode("baz"), quux=IntegerNode(4))
+        self.assertIsInstance(node.edits(twin), DataClassEdit)
+
     def test_print_renders_slots(self):
         """:meth:`DataClassNode.print` is the fallback when no formatter resolves the node type."""
         class Foo(DataClassNode):


### PR DESCRIPTION
Closes #173.

Builds on @Liyu0310-Code's work in #175, which was merged into this branch so their commit is carried over intact, and finishes it.

## The bug

`DataClassNode.__init_subclass__` accumulated slots by reading the inherited `_SLOTS` / `_SLOT_ANNOTATIONS` attributes, which resolve through the MRO to only the first inheritance chain. Under diamond inheritance the slots of every base after the first were silently dropped, so `items()`, `__iter__`, `to_obj()` and the hash all ignored them, and constructing the class failed with a misleading `TypeError: object.__init__() takes exactly one argument`.

The fix collects annotations from every data-class ancestor and derives `_SLOTS` from the merged mapping. The reproducer in #173 now gives:

```
D._SLOTS = ('a', 'c', 'b', 'd')
to_obj   = {'a': 1, 'c': 3, 'b': 2, 'd': 4}
```

## What this branch corrects

`df537d6` fixes two things in the merged change:

**The ancestors were iterated in the wrong order.** The slot merge was written against an earlier `__init_subclass__`, where `ancestors` was in plain `__mro__` order and had to be reversed to merge base-first. #166 has since rebuilt that list from `reversed(cls.__mro__)`, so it already arrives base-first, and reversing it again inverted the merge order — a diamond `class D(B, C)` came out in `B`-then-`C` order. None of the edited lines overlapped with #166's, so the change applied cleanly while its meaning changed underneath it, and `test_multiple_inheritance` failed on the merge commit. The test itself was right; only the implementation disagreed with it.

**`new_slots` had become dead.** Once `_SLOTS` is derived from the merged annotations, the list is written but never read. Ruff does not report it: `F841` wants a local that is never referenced, and `new_slots.append(...)` counts as a reference.

## Validation

- `test_multiple_inheritance` fails on `d7c0f6a` (the merge of #175) and passes here. Reinstating the extra `reversed()` reproduces the failure on this branch, so the test is pinned to the defect rather than passing incidentally.
- `uv run --frozen --extra dev pytest` — 175 passed, 19 subtests
- `uv run --frozen --extra dev ruff check graphtage test docs bindist` — clean
- `uv run --frozen --extra dev make -C docs html SPHINXOPTS="-W --keep-going"` — build succeeded

The full suite passing matters here beyond the new test: every in-tree `DataClassNode` is constructed positionally by its builder, so a change to `_SLOTS` ordering would surface as widespread failures rather than quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa
