### PR TITLE
Mark TOML tables that an edit adds or removes

### DIFF
--- a/graphtage/toml.py
+++ b/graphtage/toml.py
@@ -1,7 +1,6 @@
 import itertools
 import os
-from collections.abc import Iterator
-from typing import Optional
+from collections.abc import Iterator, Sequence
 
 import toml
 
@@ -10,7 +9,7 @@ from .edits import Replace
 from .graphtage import BuildOptions, Filetype, KeyValuePairNode, LeafNode, MappingNode, StringFormatter, StringNode
 from .printer import Printer
 from .sequences import SequenceFormatter
-from .tree import EditedTreeNode, GraphtageFormatter, TreeNode
+from .tree import Edit, EditedTreeNode, GraphtageFormatter, TreeNode
 
 
 def build_tree(path: str, options: BuildOptions | None) -> TreeNode:
@@ -165,55 +164,157 @@ def is_table(kvp: KeyValuePairNode) -> bool:
     return not (isinstance(kvp.value, EditedTreeNode) and isinstance(kvp.value.edit, Replace))
 
 
-class TOMLMapping:
-    def __init__(
-            self,
-            mapping: MappingNode,
-            parent: Optional['TOMLMapping'] = None,
-            parent_name: TreeNode | None = None
-    ):
-        self.mapping: MappingNode = mapping
-        self.parent: TOMLMapping | None = parent
-        self.parent_name: TreeNode | None = parent_name
+def key_value_pairs(mapping: MappingNode) -> Iterator[KeyValuePairNode]:
+    """Iterates over a mapping's key/value pairs, including any that an edit inserts into it.
 
-    @property
-    def name_segments(self) -> tuple[TreeNode, ...]:
-        if self.parent is None:
-            return ()
+    Args:
+        mapping: The mapping whose pairs to enumerate.
+
+    Returns:
+        Iterator[KeyValuePairNode]: Every pair the mapping renders. An inserted pair belongs to the other document,
+        so it is not among the mapping's own children.
+
+    """
+    inserted: Sequence[TreeNode] = ()
+    if isinstance(mapping, EditedTreeNode):
+        inserted = mapping.inserted
+    return itertools.chain(mapping, inserted)
+
+
+def writes_own_section(mapping: MappingNode) -> bool:
+    """Returns whether a mapping is written as a section of its own rather than only as a name prefix.
+
+    A mapping whose every pair is itself a ``[table]`` writes nothing between its own header and the first header
+    below it, so the header is omitted and the sub-tables carry the whole dotted name. An empty mapping still needs
+    a header of its own, since it would otherwise leave no trace in the output.
+
+    Args:
+        mapping: The mapping to classify.
+
+    Returns:
+        bool: :const:`True` if :obj:`mapping` writes a header and a body of its own.
+
+    """
+    pairs = list(key_value_pairs(mapping))
+    return not pairs or any(not is_table(kvp) for kvp in pairs)
+
+
+class TOMLTableFormatter(SequenceFormatter):
+    """A sub-formatter for a TOML document and for every ``[table]`` section within it.
+
+    Every pair is written through :meth:`SequenceFormatter.print_SequenceNode`, which is where an inserted or removed
+    pair is wrapped in its edit markup. A pair that becomes a section of its own is held back until the rest of its
+    table has been written, because TOML reads every ``key = value`` line that follows a header as part of that
+    header's table.
+
+    """
+    is_partial = True
+
+    def __init__(self):
+        """Initializes the TOML table formatter.
+
+        Equivalent to::
+
+            super().__init__('', '', '')
+
+        """
+        super().__init__('', '', '')
+        self._name: list[TreeNode] = []
+        self._sections: list[list[Edit]] = []
+
+    def item_newline(self, printer: Printer, is_first: bool = False, is_last: bool = False):
+        """Writes nothing, since every line of a table body already ends itself."""
+
+    def items_indent(self, printer: Printer) -> Printer:
+        """Returns :obj:`printer` itself, since TOML does not indent a table body under its header."""
+        return printer
+
+    def edit_print(self, printer: Printer, edit: Edit):
+        """Writes one pair of a table, holding back any pair that becomes a ``[table]`` section of its own.
+
+        Args:
+            printer: The printer to which to write.
+            edit: The edit for the pair, which is a :class:`graphtage.Match` when the table is not edited.
+
+        """
+        node = edit.from_node
+        if isinstance(node, KeyValuePairNode) and is_table(node):
+            self._sections[-1].append(edit)
         else:
-            return (*self.parent.name_segments, self.parent_name)
+            super().edit_print(printer, edit)
 
-    def key_value_pairs(self) -> Iterator[KeyValuePairNode]:
-        """Iterates over this mapping's key/value pairs, including any that an edit inserts into it."""
-        inserted = ()
-        if self.mapping.edited and self.mapping.inserted:
-            inserted = self.mapping.inserted
-        return itertools.chain(self.mapping, inserted)
+    def print_MappingNode(self, printer: Printer, node: MappingNode):
+        """Writes a TOML document, or one ``[table]`` section and the sections nested within it.
 
-    def items(self) -> Iterator[KeyValuePairNode]:
-        for kvp in self.key_value_pairs():
-            if not is_table(kvp):
-                yield kvp
+        Args:
+            printer: The printer to which to write.
+            node: The document root, or the value of the pair that names this section.
 
-    def __bool__(self):
+        """
+        writes_section = writes_own_section(node)
+        if writes_section and self._name:
+            self.write_header(printer)
+        self._sections.append([])
         try:
-            next(self.items())
-            return True
-        except StopIteration:
-            try:
-                next(self.children())
-                return False
-            except StopIteration:
-                return True
+            super().print_SequenceNode(printer, node)
+        finally:
+            sections = self._sections.pop()
+        if writes_section:
+            printer.newline()
+        for section in sections:
+            super().edit_print(printer, section)
 
-    def children(self) -> Iterator['TOMLMapping']:
-        for kvp in self.key_value_pairs():
-            if is_table(kvp):
-                yield TOMLMapping(mapping=kvp.value, parent=self, parent_name=kvp.key)
+    def print_KeyValuePairNode(self, printer: Printer, node: KeyValuePairNode):
+        """Writes one entry of a table, either as a ``key = value`` line or as a ``[table]`` section of its own.
+
+        Args:
+            printer: The printer to which to write.
+            node: The key/value pair to write.
+
+        """
+        if not is_table(node):
+            self.parent.write_key_value_pair(printer, node)
+            printer.newline()
+            return
+        self._name.append(node.key)
+        try:
+            self.print(printer, node.value)
+        finally:
+            self._name.pop()
+
+    def print_SequenceNode(self, *args, **kwargs):
+        """Prints a non-mapping sequence.
+
+        This delegates to the parent formatter's implementation::
+
+            self.parent.print(*args, **kwargs)
+
+        which should invoke :meth:`TOMLFormatter.print`, thereby delegating to the :class:`TOMLListFormatter` in
+        instances where a table contains a list.
+
+        """
+        self.parent.print(*args, **kwargs)
+
+    def write_header(self, printer: Printer):
+        """Writes the ``[dotted.name]`` header of the section that is currently being written.
+
+        Args:
+            printer: The printer to which to write.
+
+        """
+        printer.write('[')
+        for i, segment in enumerate(self._name):
+            if i > 0:
+                printer.write('.')
+            if isinstance(segment, StringNode):
+                segment.quoted = False
+            self.print(printer, segment)
+        printer.write(']')
+        printer.newline()
 
 
 class TOMLFormatter(GraphtageFormatter):
-    sub_format_types = (TOMLListFormatter, TOMLStringFormatter, TOMLInlineTableFormatter)
+    sub_format_types = (TOMLTableFormatter, TOMLListFormatter, TOMLStringFormatter, TOMLInlineTableFormatter)
 
     @property
     def inline_tables(self) -> TOMLInlineTableFormatter:
@@ -224,6 +325,11 @@ class TOMLFormatter(GraphtageFormatter):
 
         """
         return next(f for f in self.sub_formatters if isinstance(f, TOMLInlineTableFormatter))
+
+    @property
+    def tables(self) -> TOMLTableFormatter:
+        """The sub-formatter for a mapping that is written as a ``[table]`` section."""
+        return next(f for f in self.sub_formatters if isinstance(f, TOMLTableFormatter))
 
     def print(self, printer: Printer, *args, **kwargs):
         # TOML has optional indentation; make it only two spaces, if we use it:
@@ -257,29 +363,8 @@ class TOMLFormatter(GraphtageFormatter):
         if node.parent is not None:
             # This mapping is a value rather than the document, so there is no header to write it under:
             self.inline_tables.print_MappingNode(printer, node)
-            return
-        mappings = [TOMLMapping(node)]
-        while mappings:
-            m: TOMLMapping = mappings.pop()
-            if m:
-                name = m.name_segments
-                if name:
-                    printer.write('[')
-                    first = True
-                    for s in name:
-                        if first:
-                            first = False
-                        else:
-                            printer.write('.')
-                        if isinstance(s, StringNode):
-                            s.quoted = False
-                        self.print(printer, s)
-                    printer.write(']')
-                    printer.newline()
-                for kvp in m.items():
-                    self.print(printer, kvp)
-                printer.newline()
-            mappings.extend(m.children())
+        else:
+            self.tables.print_MappingNode(printer, node)
 
 
 class TOML(Filetype):

--- a/test/test_toml.py
+++ b/test/test_toml.py
@@ -1,6 +1,8 @@
 from io import StringIO
 from unittest import TestCase
 
+import toml
+
 import graphtage
 from graphtage.printer import Printer
 from graphtage.utils import Tempfile
@@ -28,6 +30,43 @@ a = 1
 
 NESTED_LIST_VALUE = b"""[outer]
 k = [2, 3]
+"""
+
+TWO_TABLES = b"""[keep]
+x = 1
+
+[gone]
+a = 1
+"""
+
+ONE_TABLE = b"""[keep]
+x = 1
+"""
+
+TABLE_WITH_TWO_KEYS = b"""[keep]
+x = 1
+y = 2
+"""
+
+SECTIONS = b"""title = "top"
+
+[other]
+z = 3
+
+[outer.keep]
+x = 1
+
+[outer.gone]
+a = 1
+"""
+
+SECTIONS_WITHOUT_ONE = b"""title = "top"
+
+[other]
+z = 3
+
+[outer.keep]
+x = 1
 """
 
 
@@ -84,3 +123,43 @@ class TestTOMLDiff(TestCase):
         self.assertNotIn("~~", unchanged)
         self.assertNotIn("++", unchanged)
         self.assertEqual(["[k]", "a = 1"], diff_lines(TABLE, TABLE))
+
+    def test_removed_table_is_marked(self):
+        """A whole section used to render exactly as it appears in the original, marking nothing as removed."""
+        self.assertEqual(
+            ["[keep]", "x = 1", "~~[gone]", "a = 1", "~~"],
+            diff_lines(TWO_TABLES, ONE_TABLE)
+        )
+
+    def test_inserted_table_is_marked(self):
+        """A whole section used to be written with no marker, so the diff read as though nothing was added."""
+        self.assertEqual(
+            ["[keep]", "x = 1", "++[gone]", "a = 1", "++"],
+            diff_lines(ONE_TABLE, TWO_TABLES)
+        )
+
+    def test_removed_nested_table_is_marked(self):
+        """A section below the document root keeps its dotted name and carries the removal marker."""
+        self.assertEqual(
+            ['title = "top"', "[other]", "z = 3", "[outer.keep]", "x = 1", "~~[outer.gone]", "a = 1", "~~"],
+            diff_lines(SECTIONS, SECTIONS_WITHOUT_ONE)
+        )
+
+    def test_inserted_nested_table_is_marked(self):
+        """The mirror image of the removal, since an inserted pair reaches the formatter by a different route."""
+        self.assertEqual(
+            ['title = "top"', "[other]", "z = 3", "[outer.keep]", "x = 1", "++[outer.gone]", "a = 1", "++"],
+            diff_lines(SECTIONS_WITHOUT_ONE, SECTIONS)
+        )
+
+    def test_removed_scalar_in_a_table_is_marked(self):
+        """The control for a pair that is written as a ``key = value`` line rather than as a section."""
+        self.assertEqual(["[keep]", "x = 1", "~~y = 2", "~~"], diff_lines(TABLE_WITH_TWO_KEYS, ONE_TABLE))
+
+    def test_inserted_scalar_in_a_table_is_marked(self):
+        """An inserted pair is absent from the mapping's own children, so it too used to render unmarked."""
+        self.assertEqual(["[keep]", "x = 1", "++y = 2", "++"], diff_lines(ONE_TABLE, TABLE_WITH_TWO_KEYS))
+
+    def test_document_with_several_sections_round_trips(self):
+        """Every ``key = value`` line must precede the first header below it, or TOML reparses it into that table."""
+        self.assertEqual(toml.loads(SECTIONS.decode("utf-8")), toml.loads(render_diff(SECTIONS, SECTIONS)))


### PR DESCRIPTION
Closes #179

## Root cause

`TOMLMapping` flattened the document by walking the mapping's child nodes and writing each `[table]` header and body itself. A section therefore never reached `Remove.print` or `Insert.print`, and the markup had nowhere to attach: the two documents' sections came out merged into a single listing with nothing to say which of them had changed.

The issue attributes the failure to sections alone. That is most of it, but the walk also dropped every *insertion*, scalar or not. The two paths differ:

- A removed pair survives the walk because `Remove.on_diff` records the edit on the node it removes, and the walk hands that node to the printing protocol. That is why `~~y = 2~~` already rendered.
- An inserted pair belongs to the *other* document and reaches the mapping only through `EditedTreeNode.inserted`. `Insert.on_diff` records nothing on the node itself, so the walk wrote it as plain text. `graphtage a.toml b.toml` reported `y = 2` with no `++` markers even though it is a new key.

So the silent-wrong-answer class covered three cases, not one: a removed section, an inserted section, and an inserted `key = value` line.

## Fix

Route the document and every section through `SequenceFormatter.print_SequenceNode`, which enumerates the mapping's *edits* rather than its children, and move the header into a new `TOMLTableFormatter.print_KeyValuePairNode` so that the header and the body both sit inside whatever markup wraps the pair. `graphtage/ini.py` has the same shape.

The one TOML-specific wrinkle is ordering: TOML reads every `key = value` line that follows a header as part of that header's table, so a table's own lines must precede the first header below it. `TOMLTableFormatter.edit_print` holds back any pair that becomes a section of its own and replays those pairs once the rest of the table has been written. Every pair still passes through `print_SequenceNode` exactly once, so no edit is dropped.

`TOMLMapping` is deleted; its `key_value_pairs` helper (added in #178) becomes a module-level function, used now only to decide whether a mapping writes a header of its own or is merely a prefix of its sub-tables' dotted names.

## Before and after

```console
$ printf '[keep]\nx = 1\n\n[gone]\na = 1\n' > t1.toml
$ printf '[keep]\nx = 1\n' > t2.toml
```

Before, on `959925b` — nothing is marked, but the exit status is 1:

```toml
[keep]
x = 1

[gone]
a = 1
```

After:

```toml
[keep]
x = 1

~~[gone]
a = 1

~~
```

Insertion, `t2.toml` against a document that adds `[added]`:

```toml
[keep]
x = 1

++[added]
b = 2

++
```

An inserted scalar, which was also unmarked before:

```toml
[keep]
x = 1
++y = 2
++
```

## Validation

- `test/test_toml.py` gains seven cases: a removed table, an inserted table, a removed and an inserted nested table under a document that also has a top-level scalar and a sibling section, a removed and an inserted scalar inside a table, and a round-trip check that the rendered document reparses to the same object. Run against the unfixed `graphtage/toml.py`, the five markup cases fail (each renders the section or the pair with no marker at all) and the two controls pass. All thirteen pass after the fix.
- The pre-existing controls are unchanged and still pass: the replaced table and replaced nested table from #174, a replaced scalar, a table whose value stays a table, and an unchanged document.
- `uv run --frozen --extra dev ruff check graphtage test docs bindist` — clean.
- `uv run --frozen --extra dev pytest` — 191 passed. This includes `test_toml_formatting`, the 200-iteration round-trip fuzzer; it only exercises unedited trees, so it is a guard against breaking ordinary rendering rather than a check on edits. Re-run under three additional `GRAPHTAGE_TEST_SEED` values.
- `uv run --frozen --extra dev make -C docs html SPHINXOPTS="-W --keep-going"` — build succeeded.
- Spot-checked ANSI colour (strike-through and under-plus combining marks over the whole section) and `--html` (the `~~` markers appear; the output has the same shape as INI's). Confirmed that a document with a top-level scalar, an empty table, sibling tables, and three levels of nesting still renders as valid TOML that reparses to the original object.

## Note on output ordering

Sections now come out in the order the sequence protocol yields them: matched sections first, then removals and insertions, and ascending by key within each group. The old stack-based walk emitted siblings in descending key order, an artifact of `list.pop()`. Section names are fully qualified either way, so both orderings are valid TOML; the new one matches JSON and INI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypKU5KdLfs2Cf8kS2TzJa
