### PR TITLE
Print inserted XML attributes and child elements

### DIFF
--- a/graphtage/xml.py
+++ b/graphtage/xml.py
@@ -393,9 +393,14 @@ class XMLFormatter(GraphtageFormatter):
     def print_XMLElement(self, printer: Printer, node: XMLElement):
         printer.write('<')
         self.print(printer, node.tag)
-        if node.attrib:
-            self.print(printer, node.attrib)
-        if node._children._children or (node.text is not None and '\n' in node.text.object):
+        # Always hand attrib to the formatter. An empty from-side DictNode is
+        # falsy, so a truthiness guard dropped Insert edits on the first attribute.
+        self.print(printer, node.attrib)
+        child_edit = getattr(node._children, 'edit', None)
+        has_child_edits = child_edit is not None and not isinstance(child_edit, Match)
+        if node._children._children or has_child_edits or (
+            node.text is not None and '\n' in node.text.object
+        ):
             printer.write('>')
             if node.text is not None:
                 self.print(printer, node.text)

--- a/test/test_xml.py
+++ b/test/test_xml.py
@@ -1,5 +1,8 @@
 import unittest
+from io import StringIO
 
+import graphtage
+from graphtage.printer import Printer
 from graphtage.utils import Tempfile
 from graphtage.xml import XML
 
@@ -29,3 +32,56 @@ class TestXML(unittest.TestCase):
             t2 = xml.build_tree(two)
             for edit in t1.get_all_edits(t2):
                 print(edit)
+
+
+def build(content: bytes) -> graphtage.TreeNode:
+    with Tempfile(content) as path:
+        return graphtage.FILETYPES_BY_TYPENAME["xml"].build_tree(path)
+
+
+def render(node: graphtage.TreeNode) -> str:
+    stream = StringIO()
+    printer = Printer(out_stream=stream, ansi_color=False)
+    graphtage.FILETYPES_BY_TYPENAME["xml"].get_default_formatter().print(printer, node)
+    printer.flush(final=True)
+    return stream.getvalue()
+
+
+def render_diff(from_content: bytes, to_content: bytes) -> str:
+    return render(build(from_content).diff(build(to_content)))
+
+
+class TestXMLDiff(unittest.TestCase):
+    """Covers XML formatter edit printing, which the unedited round-trip tests cannot reach."""
+
+    def test_inserted_attribute_on_bare_element_is_marked(self):
+        """Adding the first attribute used to vanish because if node.attrib skipped an empty DictNode."""
+        rendered = render_diff(b"<r><d>x</d></r>", b'<r><d a="1">x</d></r>')
+        self.assertIn("a", rendered)
+        self.assertIn("++", rendered)
+        self.assertIn("1", rendered)
+
+    def test_inserted_child_element_is_marked(self):
+        """A new child on an element that already had text used to be omitted from the rendered tree."""
+        rendered = render_diff(b"<r><d>x</d></r>", b"<r><d>x<e>y</e></d></r>")
+        self.assertIn("<e>", rendered)
+        self.assertIn("y", rendered)
+        self.assertIn("++", rendered)
+
+    def test_inserted_child_on_empty_element_is_not_self_closed(self):
+        """An empty element used to stay self-closing, hiding the inserted subtree."""
+        rendered = render_diff(b"<r><d></d></r>", b"<r><d><e>y</e></d></r>")
+        self.assertNotIn("<d />", rendered)
+        self.assertIn("<e>", rendered)
+        self.assertIn("y", rendered)
+
+    def test_adding_an_attribute_when_one_exists_still_works(self):
+        rendered = render_diff(b'<r><d a="1">x</d></r>', b'<r><d a="1" b="2">x</d></r>')
+        self.assertIn("b", rendered)
+        self.assertIn("++", rendered)
+
+    def test_unchanged_empty_element_stays_self_closing(self):
+        rendered = render_diff(b"<r><d></d></r>", b"<r><d></d></r>")
+        self.assertIn("<d />", rendered)
+        self.assertNotIn("++", rendered)
+        self.assertNotIn("~~", rendered)


### PR DESCRIPTION
Fixes #186

print_XMLElement skipped an empty attrib dict and an empty child list, so the first added attribute or a new child never reached SequenceFormatter.

The formatter now always prints attrib. It also prints children when they have a non-Match edit, so an empty element does not stay self-closing over an insert. Unchanged empty elements still self-close.

Tests cover adding the first attribute, inserting a child next to text, inserting a child into an empty element, adding an attribute when one already exists, and leaving an empty element unchanged.