### PR TITLE
Print XML through non-XML formatters without re-parenting

### DIFF
--- a/graphtage/xml.py
+++ b/graphtage/xml.py
@@ -30,6 +30,7 @@ from .json import JSONFormatter
 from .printer import Fore, Printer
 from .sequences import SequenceFormatter
 from .tree import Edit, EditedTreeNode, GraphtageFormatter, TreeNode
+from .yaml import YAMLFormatter
 
 
 class XMLElementEdit(AbstractCompoundEdit):
@@ -456,17 +457,32 @@ class HTML(XML):
         )
 
 
-# Tell JSON how to format XML:
-def _json_print_XMLElement(self: JSONFormatter, printer: Printer, node: XMLElement):
+def _xml_element_json_view(node: XMLElement) -> DictNode:
+    """Build a JSON dict view that owns its children.
+
+    Wrapping ``node.tag`` and the other live children in a new :class:`KeyValuePairNode` re-parents them and raises
+    ``ValueError`` once nodes gained parents in v0.2.7. Copies and a recursive dict for nested elements keep the
+    original tree intact.
+
+    """
     kvps = [
-        KeyValuePairNode(StringNode('tag'), node.tag),
+        KeyValuePairNode(StringNode('tag'), node.tag.copy()),
     ]
     if len(node.attrib) > 0:
-        kvps.append(KeyValuePairNode(StringNode('attrs'), node.attrib))
+        kvps.append(KeyValuePairNode(StringNode('attrs'), node.attrib.copy()))
     if node.text is not None:
-        kvps.append(KeyValuePairNode(StringNode('text'), node.text))
-    kvps.append(KeyValuePairNode(StringNode('children'), node._children))
-    self.print(printer, DictNode(kvps))
+        kvps.append(KeyValuePairNode(StringNode('text'), node.text.copy()))
+    kvps.append(KeyValuePairNode(
+        StringNode('children'),
+        ListNode(_xml_element_json_view(child) for child in node._children)
+    ))
+    return DictNode(kvps)
+
+
+# Tell JSON how to format XML:
+def _json_print_XMLElement(self: JSONFormatter, printer: Printer, node: XMLElement):
+    self.print(printer, _xml_element_json_view(node))
 
 
 JSONFormatter.print_XMLElement = _json_print_XMLElement
+YAMLFormatter.print_XMLElement = _json_print_XMLElement

--- a/graphtage/yaml.py
+++ b/graphtage/yaml.py
@@ -213,8 +213,8 @@ class YAMLFormatter(GraphtageFormatter):
         This is a fallback to permit the printing of custom containers, like :class:`graphtage.xml.XMLElement`.
 
         """
-        # Treat the container like a list
-        list_node = ListNode(node.children())
+        # Treat the container like a list. Copy so live children are not re-parented.
+        list_node = ListNode(c.copy() for c in node.children())
         self.print(printer, list_node)
 
 

--- a/test/test_xml.py
+++ b/test/test_xml.py
@@ -1,5 +1,8 @@
 import unittest
+from io import StringIO
 
+import graphtage
+from graphtage.printer import Printer
 from graphtage.utils import Tempfile
 from graphtage.xml import XML
 
@@ -29,3 +32,59 @@ class TestXML(unittest.TestCase):
             t2 = xml.build_tree(two)
             for edit in t1.get_all_edits(t2):
                 print(edit)
+
+
+def _render_with_formatter(tree: graphtage.TreeNode, formatter) -> str:
+    stream = StringIO()
+    printer = Printer(out_stream=stream, ansi_color=False)
+    formatter.print(printer, tree)
+    printer.flush(final=True)
+    return stream.getvalue()
+
+
+class TestXMLCrossFormat(unittest.TestCase):
+    """Covers https://github.com/trailofbits/graphtage/issues/187."""
+
+    XML_SAMPLE = b"<r><d>x</d></r>"
+    HTML_SAMPLE = b"<html><body>x</body></html>"
+    OUTPUT_FORMATS = ("xml", "html", "json", "json5", "yaml", "toml", "csv", "ini", "plist")
+
+    def _build(self, typename: str, content: bytes) -> graphtage.TreeNode:
+        with Tempfile(content) as path:
+            return graphtage.FILETYPES_BY_TYPENAME[typename].build_tree(path)
+
+    def test_xml_to_json_does_not_raise(self):
+        tree = self._build("xml", self.XML_SAMPLE)
+        rendered = _render_with_formatter(
+            tree.diff(tree),
+            graphtage.FILETYPES_BY_TYPENAME["json"].get_default_formatter(),
+        )
+        self.assertIn("tag", rendered)
+        self.assertIn("r", rendered)
+
+    def test_identical_xml_through_every_formatter(self):
+        tree = self._build("xml", self.XML_SAMPLE)
+        diff = tree.diff(self._build("xml", self.XML_SAMPLE))
+        for name in self.OUTPUT_FORMATS:
+            with self.subTest(format=name):
+                formatter = graphtage.FILETYPES_BY_TYPENAME[name].get_default_formatter()
+                rendered = _render_with_formatter(diff, formatter)
+                self.assertIsInstance(rendered, str)
+
+    def test_identical_html_through_every_formatter(self):
+        tree = self._build("html", self.HTML_SAMPLE)
+        diff = tree.diff(self._build("html", self.HTML_SAMPLE))
+        for name in self.OUTPUT_FORMATS:
+            with self.subTest(format=name):
+                formatter = graphtage.FILETYPES_BY_TYPENAME[name].get_default_formatter()
+                rendered = _render_with_formatter(diff, formatter)
+                self.assertIsInstance(rendered, str)
+
+    def test_xml_diff_through_json_does_not_raise(self):
+        left = self._build("xml", self.XML_SAMPLE)
+        right = self._build("xml", b"<r><d>y</d></r>")
+        rendered = _render_with_formatter(
+            left.diff(right),
+            graphtage.FILETYPES_BY_TYPENAME["json"].get_default_formatter(),
+        )
+        self.assertIn("tag", rendered)


### PR DESCRIPTION
Fixes #187

_json_print_XMLElement wrapped live tag, attribute, text, and child nodes in a new DictNode. Those nodes already had a parent, so the first KeyValuePairNode raised ValueError for every non-XML output format.

The JSON view now copies those nodes and builds a dict it owns. YAML uses the same printer, because its ContainerNode fallback hit the same parent check.

Tests render a small XML and HTML tree through each registered formatter and cover a JSON-formatted XML diff.